### PR TITLE
EM-1543 - Ignore CTS pin to reduce IRQ storm

### DIFF
--- a/dts/sun7i-a20-opinicus_emmc_v1.dts
+++ b/dts/sun7i-a20-opinicus_emmc_v1.dts
@@ -224,6 +224,7 @@
 &uart3 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&uart3_pins_a>;
+	cts-override;
 	status = "okay";
 };
 


### PR DESCRIPTION
UART3 used for marlin communication is a 4 pin port, it has rx, tx and RTS CTS
lines. We are not using the RTS and CTS line, but noise may trigger false
interrupts here. Ignore the CTS bits from the uart.

EM-1534

Signed-off-by: Olliver Schinagl <o.schinagl@ultimaker.com>