### PR TITLE
Ensure there is 3.3 volt on port G

### DIFF
--- a/dts/jedi-common.dts
+++ b/dts/jedi-common.dts
@@ -1,5 +1,10 @@
 #include "sun7i-a20-olinuxino-lime2-emmc.dts"
 
+&reg_ldo3 {
+    regulator-min-microvolt = <3300000>;
+    regulator-max-microvolt = <3300000>;
+};
+
 &usb_otg {
     dr_mode = "host";
 };


### PR DESCRIPTION
Port G is powered by LDO4, but LDO4 is set to 2.8 volt by default.

Ensure there is at least enough power on LDO4 available.

Note that currently this is only a cosmetic/futureproofing fix.
U-Boot is currently responsible for setting the initial voltage of
LDO4. To fix this, a consumer is needed on the IO controller.

EM-1631

Signed-off-by: Olliver Schinagl <o.schinagl@ultimaker.com>