### PR TITLE
EM-2406 Add support for rfkill on our usb hosts

### DIFF
--- a/dts/part2005-olimexinterface.dtsi
+++ b/dts/part2005-olimexinterface.dtsi
@@ -65,6 +65,24 @@
             default-state = "on";
         };
     };
+
+    usb0-kill {
+        compatible = "linux,rfkill-gpio";
+        type = "fm";
+        shutdown-gpios = <&pio 2 17 GPIO_ACTIVE_HIGH>;
+    };
+
+    usb1-kill {
+        compatible = "linux,rfkill-gpio";
+        type = "fm";
+        shutdown-gpios = <&pio 7 6 GPIO_ACTIVE_HIGH>;
+    };
+
+    usb2-kill {
+        compatible = "linux,rfkill-gpio";
+        type = "fm";
+        shutdown-gpios = <&pio 7 3 GPIO_ACTIVE_HIGH>;
+    };
 };
 
 &i2c2 {
@@ -81,6 +99,18 @@
         drive-strength = <20>;
         bias-disabled;
     };
+};
+
+&reg_usb0_vbus {
+    /delete-property/ gpio;
+};
+
+&reg_usb1_vbus {
+    /delete-property/ gpio;
+};
+
+&reg_usb2_vbus {
+    /delete-property/ gpio;
 };
 
 &spi1 {

--- a/dts/part2621-ultimainboard3.1.dtsi
+++ b/dts/part2621-ultimainboard3.1.dtsi
@@ -71,6 +71,24 @@
 			default-state = "on";
 		};
 	};
+
+	usb0-kill {
+		compatible = "linux,rfkill-gpio";
+		type = "fm";
+		shutdown-gpios = <&pio 2 17 GPIO_ACTIVE_HIGH>;
+	};
+
+	usb1-kill {
+		compatible = "linux,rfkill-gpio";
+		type = "fm";
+		shutdown-gpios = <&pio 7 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	usb2-kill {
+		compatible = "linux,rfkill-gpio";
+		type = "fm";
+		shutdown-gpios = <&pio 7 3 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &i2c1 {
@@ -136,6 +154,18 @@
 		drive-strength = <20>;
 		bias-disabled;
 	};
+};
+
+&reg_usb0_vbus {
+	/delete-property/ gpio;
+};
+
+&reg_usb1_vbus {
+	/delete-property/ gpio;
+};
+
+&reg_usb2_vbus {
+	/delete-property/ gpio;
 };
 
 &spi1 {


### PR DESCRIPTION
This patch enables rfkill to be used on our usb hosts. Currently,
rfkill is not the designed framework for this, as it is explicitly
described for radio-frequency devices, but until we have a devkill or
similar device for this purpose, it will have to 'abuse' rfkill. This
abuse happens only in the devicetree. The kernel itself just see's a
wifi gpio.

Contributes to issue: EM-2406

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>