### PR TITLE
Add root device to startup script parameters

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -136,8 +136,8 @@ find_and_run_update()
 		fi
 
 		echo "Found '${SYSTEM_UPDATE_ENTRYPOINT}' script, trying to execute."
-		if ! "${SYSTEM_UPDATE_ENTRYPOINT}" "${UPDATE_MOUNT}"; then
-			echo "Update failed: Error executing '${SYSTEM_UPDATE_ENTRYPOINT} ${UPDATE_MOUNT}'."
+		if ! "${SYSTEM_UPDATE_ENTRYPOINT}" "${UPDATE_MOUNT}" "${root}"; then
+			echo "Update failed: Error executing '${SYSTEM_UPDATE_ENTRYPOINT} ${UPDATE_MOUNT} ${root}'."
 			critical_error
 			break;
 		fi


### PR DESCRIPTION
The startup script needs to know on which device to perform operations.
As such, we need to pass the current root device along.

Addresses EMP-272, contributes to EMP-391.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>