### PR TITLE
Fix error UPDATE_ROOT not found.

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -176,7 +176,7 @@ find_and_run_update()
 
         echo "Got '${SYSTEM_UPDATE_ENTRYPOINT}' script, trying to execute."
         if ! "${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT}" "${update_tmpfs_mount}/${UPDATE_IMAGE}" "${base_dev}"; then
-            echo "Error, update failed: executing '${SYSTEM_UPDATE_ENTRYPOINT} ${UPDATE_MOUNT} ${UPDATE_SRC_MOUNT} ${base_dev}'."
+            echo "Error, update failed: executing '${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT} ${update_tmpfs_mount}/${UPDATE_IMAGE} ${base_dev}'."
             critical_error
             break;
         fi


### PR DESCRIPTION
The interface changed for the jedi-system-update/start_udpate.sh script,
but the tracing output was still using the old variable that do not
exist anymore.

Contributes to EMP-421

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>