### PR TITLE
Fix error in kernel build because of broken download URL.

### DIFF
--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -53,7 +53,7 @@ INITRAMFS_IMG="${KERNEL_BUILD}/initramfs.cpio${INITRAMFS_COMPRESSION}"
 GEN_INIT_CPIO="${KERNEL_BUILD}/usr/gen_init_cpio"
 GEN_INITRAMFS_LIST="${KERNEL}/scripts/gen_initramfs_list.sh"
 
-BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.28.4-r1.apk"
+BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.28.4-r2.apk"
 BB_BIN="busybox"
 
 DEPMOD="${DEPMOD:-/sbin/depmod}"
@@ -95,7 +95,11 @@ busybox_get()
         exit 1
     fi
 
-    wget -q "${BB_PKG}" -O "${BB_APK}"
+    if ! wget -q "${BB_PKG}" -O "${BB_APK}"; then
+        echo "Unable to download the busybox package '${BB_PKG}'. Update the download URL."
+        exit 1
+    fi
+
     tar -xf "${BB_APK}" --strip=1 -C "${BB_DIR}" "bin/busybox.static"
     mv "${BB_DIR}/busybox.static" "${DEST_DIR}/${BB_BIN}"
     rm -r "${BB_DIR}"


### PR DESCRIPTION
The kernel build was failing because the busybox version URL is broken.
It has been updated to a new version. For now implemented a workaround
with a new version URL and at least notify the user if something is
wrong with the download.
An issue is logged to implement a proper fix EMP-20.

This issue addresses EMP-538.

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>