### PR TITLE
Fix error in kernel build because of broken download URL.

### DIFF
--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -53,7 +53,7 @@ INITRAMFS_IMG="${KERNEL_BUILD}/initramfs.cpio${INITRAMFS_COMPRESSION}"
 GEN_INIT_CPIO="${KERNEL_BUILD}/usr/gen_init_cpio"
 GEN_INITRAMFS_LIST="${KERNEL}/scripts/gen_initramfs_list.sh"
 
-BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.28.4-r2.apk"
+BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.28.4-r3.apk"
 BB_BIN="busybox"
 
 DEPMOD="${DEPMOD:-/sbin/depmod}"


### PR DESCRIPTION
The kernel build was failing because the busybox version URL is broken.
It has been updated to a new version. For now implemented a workaround
with a new version URL and at least notify the user if something is
wrong with the download.
An issue is logged to implement a proper fix EMP-20.

This issue addresses EMP-538.

version is now: busybox-static-1.28.4-r3

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>