### PR TITLE
Fix unable to control recovery console from uboot

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -311,7 +311,7 @@ toolcheck
 kernel_mount
 parse_cmdline
 enable_framebuffer_device
-if [ "${RESCUE_SHELL}" -eq "yes" ]; then
+if [ "${RESCUE_SHELL}" = "yes" ]; then
     rescue_shell
 fi
 


### PR DESCRIPTION
Bug in comparing string -eq is for numerical comparison.

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>