### PR TITLE
[EMP-554] Add S5 graphics module driver loading to initrd

### DIFF
--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -43,7 +43,7 @@ DEB_DIR=`pwd`/debian
 KCONFIG=`pwd`/configs/${BUILDCONFIG}_config
 KERNEL_BUILD=`pwd`/_build_armhf/${BUILDCONFIG}-linux
 
-INITRAMFS_MODULES_REQUIRED="sunxi_wdt.ko ssd1307fb.ko"
+INITRAMFS_MODULES_REQUIRED="sunxi_wdt.ko ssd1307fb.ko drm.ko sun4i-backend.ko sun4i-drm.ko sun4i-tcon.ko sun4i-drm-hdmi.ko sun4i-hdmi-i2c.ko"
 INITRAMFS_COMPRESSION="${INITRAMFS_COMPRESSION:-.lzo}"
 INITRAMFS_ROOT_GID=${INITRAMFS_ROOT_GID:-0}
 INITRAMFS_ROOT_UID=${INITRAMFS_ROOT_UID:-0}

--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -143,7 +143,12 @@ enable_framebuffer_device()
     if [ -z "${UM3_DISPLAY_ARTICLE_NUMBERS##*${ARTICLE_NUMBER}*}" ]; then
         modprobe -v ssd1307fb || true
     elif [ -z "${SLINE_DISPLAY_ARTICLE_NUMBERS##*${ARTICLE_NUMBER}*}" ]; then
-        echo "S-Line framebuffer support not enabled in initramfs."
+        modprobe sun4i-drm-hdmi || true
+        modprobe sun4i-hdmi-i2c || true
+        modprobe sun4i-tcon || true
+        modprobe sun4i-backend || true
+        modprobe rc-core || true
+        modprobe sun4i-drm || true
     fi
 }
 


### PR DESCRIPTION
In order to be able to show images on the framebuffer for the
ne update mechanism, the framebuffer must be available in the
initrd stage, i.e. the stage wherein the update tooling is executed.

Contributes to EMP-479 addresses EMP-554

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>