### PR TITLE
Fix 'login required for Linux submodule'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "linux"]
 	path = linux
-	url = https://github.com/Ultimaker/linux.git
+	url = ssh://git@github.com/Ultimaker/linux.git


### PR DESCRIPTION
The submodule was setup to use https, not making use of
publick-key authentication.

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>