### PR TITLE
Emp 607 fix dependency issues initramfs build

### DIFF
--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -27,8 +27,8 @@ if [ "${MAKEFLAGS}" == "" ]; then
     echo -e "\e[0m"
 fi
 
-set -e
-set -u
+set -eu
+
 CWD="$(pwd)"
 
 # Which kernel to build

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -169,7 +169,7 @@ initramfs_prepare()
         busybox_get "${INITRAMFS_DST_DIR}"
     fi
 
-    if [ -d "${INITRAMFS_MODULES_DIR}" ]; then
+    if [ -d "${INITRAMFS_MODULES_DIR}" ] && [ -z "${INITRAMFS_MODULES_DIR##*/initramfs/lib/modules*}" ]; then
         rm -rf "${INITRAMFS_MODULES_DIR}"
     fi
 

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -6,10 +6,10 @@
 # using arm-none-eabi-gcc, so we need to ensure it exists. Because printenv and
 # which can cause bash -e to exit, so run this before setting this up.
 if [ "${CROSS_COMPILE}" == "" ]; then
-    if [ "$(which arm-none-eabi-gcc)" != "" ]; then
+    if [ "$(command -v arm-none-eabi-gcc)" != "" ]; then
         CROSS_COMPILE="arm-none-eabi-"
     fi
-    if [ "$(which arm-linux-gnueabihf-gcc)" != "" ]; then
+    if [ "$(command -v arm-linux-gnueabihf-gcc)" != "" ]; then
         CROSS_COMPILE="arm-linux-gnueabihf-"
     fi
     if [ "${CROSS_COMPILE}" == "" ]; then

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -18,7 +18,7 @@ if [ "${CROSS_COMPILE}" == "" ]; then
         exit 1
     fi
 fi
-export CROSS_COMPILE=${CROSS_COMPILE}
+export CROSS_COMPILE="${CROSS_COMPILE}"
 
 if [ "${MAKEFLAGS}" == "" ]; then
     echo -e -n "\e[1m"
@@ -32,7 +32,7 @@ set -eu
 CWD="$(pwd)"
 
 # Which kernel to build
-LINUX_SRC_DIR="${CWD}/linux"
+LINUX_SRC_DIR=${CWD}/linux
 
 # Which kernel config to build.
 BUILDCONFIG="opinicus"
@@ -47,8 +47,8 @@ SCRIPTS_DIR="${CWD}/scripts"
 
 INITRAMFS_MODULES_REQUIRED="sunxi_wdt.ko ssd1307fb.ko drm.ko sun4i-backend.ko sun4i-drm.ko sun4i-tcon.ko sun4i-drm-hdmi.ko sun4i-hdmi-i2c.ko"
 INITRAMFS_COMPRESSION="${INITRAMFS_COMPRESSION:-.lzo}"
-INITRAMFS_ROOT_GID=${INITRAMFS_ROOT_GID:-0}
-INITRAMFS_ROOT_UID=${INITRAMFS_ROOT_UID:-0}
+INITRAMFS_ROOT_GID="${INITRAMFS_ROOT_GID:-0}"
+INITRAMFS_ROOT_UID="${INITRAMFS_ROOT_UID:-0}"
 INITRAMFS_SOURCE="${INITRAMFS_SOURCE:-initramfs/initramfs.lst}"
 INITRAMFS_IMG="${KERNEL_BUILD_DIR}/initramfs.cpio${INITRAMFS_COMPRESSION}"
 
@@ -68,7 +68,7 @@ if [ ! -x "${DEPMOD}" ]; then
 fi
 
 # Set the release version if it's not passed to the script
-RELEASE_VERSION=${RELEASE_VERSION:-9999.99.99}
+RELEASE_VERSION="${RELEASE_VERSION:-9999.99.99}"
 
 # Initialize repositories
 git submodule init
@@ -82,10 +82,9 @@ git submodule update
 #
 busybox_get()
 {
-    local BB_DIR=$(mktemp -d)
-    local BB_APK="${BB_DIR}/busybox-static_armhf.apk"
-    local DEST_DIR="${1}"
-    local cwd=$(pwd)
+    BB_DIR="$(mktemp -d)"
+    BB_APK="${BB_DIR}/busybox-static_armhf.apk"
+    DEST_DIR="${1}"
 
     if [ ! -d "${DEST_DIR}" ]; then
         echo "No initramfs dir set to download busybox into."
@@ -288,29 +287,29 @@ dtb_build() {
 
     # Build the device trees that we need
     for dts in $(find dts/ -name '*.dts' -exec basename {} \;); do
-        dt=${dts%.dts}
-        echo "Building devicetree blob ${dt}"
+        dt="${dts%.dts}"
+        echo "Building devicetree blob '${dt}'"
         cpp -nostdinc -undef -D__DTS__ -x assembler-with-cpp \
             -I "${LINUX_SRC_DIR}/include" -I "${LINUX_SRC_DIR}/arch/arm/boot/dts" \
             -o "${KERNEL_BUILD_DIR}/dtb/.${dt}.dtb.tmp" "dts/${dts}"
         dtc -I dts -o "${BOOT_FILE_OUTPUT_DIR}/${dt}.dtb" -O dtb "${KERNEL_BUILD_DIR}/dtb/.${dt}.dtb.tmp"
     done
 
-    while IFS='' read -r LINE || [[ -n "$LINE" ]]; do
-        if [[ $LINE != "#"* && $LINE != "" ]]; then
-            ARTICLE_FULL=$(cut -d':' -f1 <<< "${LINE}")
-            DTS=$(cut -d':' -f2 <<<"${LINE}")
+    while IFS='' read -r LINE || [ -n "${LINE}" ]; do
+        if [ -n "${LINE###*}" ] && [ "${LINE}" != "" ]; then
+            ARTICLE_FULL="$(cut -d':' -f1 <<< "${LINE}")"
+            DTS="$(cut -d':' -f2 <<<"${LINE}")"
 
-            ARTICLE_NUMBER=$(cut -d'-' -f1 <<< "${ARTICLE_FULL}")
-            ARTICLE_REV=$(cut -d'-' -s -f2 <<< "${ARTICLE_FULL}")
+            ARTICLE_NUMBER="$(cut -d'-' -f1 <<< "${ARTICLE_FULL}")"
+            ARTICLE_REV="$(cut -d'-' -s -f2 <<< "${ARTICLE_FULL}")"
 
-            ARTICLE_NUMBER_HEX=$(printf "%x\n" ${ARTICLE_NUMBER})
-            ARTICLE_REV_HEX=$(printf "%x\n" ${ARTICLE_REV})
+            ARTICLE_NUMBER_HEX="$(printf "%x\n" "${ARTICLE_NUMBER}")"
+            ARTICLE_REV_HEX="$(printf "%x\n" "${ARTICLE_REV}")"
 
-            if [[ -z "${ARTICLE_REV}" ]]; then
-                NAME=${ARTICLE_NUMBER_HEX}.dtb
+            if [ -z "${ARTICLE_REV}" ]; then
+                NAME="${ARTICLE_NUMBER_HEX}.dtb"
             else
-                NAME=${ARTICLE_NUMBER_HEX}-${ARTICLE_REV_HEX}.dtb
+                NAME="${ARTICLE_NUMBER_HEX}-${ARTICLE_REV_HEX}.dtb"
             fi
 
             ln -s "${DTS}.dtb" "${BOOT_FILE_OUTPUT_DIR}/${NAME}"
@@ -326,8 +325,8 @@ bootscript_build() {
     fi
 
     # Generate the boot splash script
-    gcc -Wall -Werror -std=c99 scripts/ultimaker_boot_splash_generator.c -o scripts/ultimaker_boot_splash_generator
-    BOOTSPLASH_COMMANDS=$(scripts/ultimaker_boot_splash_generator)
+    gcc -Wall -Werror -std=c99 "scripts/ultimaker_boot_splash_generator.c" -o "scripts/ultimaker_boot_splash_generator"
+    BOOTSPLASH_COMMANDS="$(scripts/ultimaker_boot_splash_generator)"
 
     # Create the boot-scripts for these Kernels
     ROOT_DEV=mmcblk0p2 ROOT_FS=ext4 BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst '${ROOT_DEV} ${ROOT_FS} ${BOOTSPLASH_COMMANDS}' < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_mmc.cmd"

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -43,7 +43,6 @@ KERNEL_BUILD_DIR="${CWD}/_build_armhf/${BUILDCONFIG}-linux"
 BUILD_OUTPUT_DIR="${CWD}/_build_armhf/"
 DEBIAN_DIR="${BUILD_OUTPUT_DIR}/debian"
 BOOT_FILE_OUTPUT_DIR="${DEBIAN_DIR}/boot"
-SCRIPTS_DIR="${CWD}/scripts"
 
 INITRAMFS_MODULES_REQUIRED="sunxi_wdt.ko ssd1307fb.ko drm.ko sun4i-backend.ko sun4i-drm.ko sun4i-tcon.ko sun4i-drm-hdmi.ko sun4i-hdmi-i2c.ko"
 INITRAMFS_COMPRESSION="${INITRAMFS_COMPRESSION:-.lzo}"

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -377,9 +377,9 @@ bootscript_build()
     BOOTSPLASH_COMMANDS="$(scripts/ultimaker_boot_splash_generator)"
 
     # Create the boot-scripts for these Kernels
-    ROOT_DEV=mmcblk0p2 ROOT_FS=ext4 BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst '${ROOT_DEV} ${ROOT_FS} ${BOOTSPLASH_COMMANDS}' < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_mmc.cmd"
-    ROOT_DEV=mmcblk0p2 ROOT_FS=ext4 BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst '${ROOT_DEV} ${ROOT_FS} ${BOOTSPLASH_COMMANDS}' < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_installer.cmd"
-    ROOT_DEV=mmcblk1p2 ROOT_FS=f2fs BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst '${ROOT_DEV} ${ROOT_FS} ${BOOTSPLASH_COMMANDS}' < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_emmc.cmd"
+    ROOT_DEV=mmcblk0p2 ROOT_FS=ext4 BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst "\${ROOT_DEV},\${ROOT_FS},\${BOOTSPLASH_COMMANDS}" < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_mmc.cmd"
+    ROOT_DEV=mmcblk0p2 ROOT_FS=ext4 BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst "\${ROOT_DEV},\${ROOT_FS},\${BOOTSPLASH_COMMANDS}" < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_installer.cmd"
+    ROOT_DEV=mmcblk1p2 ROOT_FS=f2fs BOOTSPLASH_COMMANDS="${BOOTSPLASH_COMMANDS}" envsubst "\${ROOT_DEV},\${ROOT_FS},\${BOOTSPLASH_COMMANDS}" < scripts/bootscript.cmd > "${BOOT_FILE_OUTPUT_DIR}/boot_emmc.cmd"
 
     # Convert the boot-scripts into proper U-Boot script images
     for CMD_FILE in "${BOOT_FILE_OUTPUT_DIR}/"*".cmd"; do
@@ -420,7 +420,7 @@ deb_build()
     fi
 
     # Create a Debian control file to pack up a Debian package
-    RELEASE_VERSION="${RELEASE_VERSION}" envsubst '${RELEASE_VERSION}' < scripts/debian_control > "${DEBIAN_DIR}/DEBIAN/control"
+    RELEASE_VERSION="${RELEASE_VERSION}" envsubst "\${RELEASE_VERSION}" < scripts/debian_control > "${DEBIAN_DIR}/DEBIAN/control"
 
     # Build the Debian package
     fakeroot dpkg-deb --build "${DEBIAN_DIR}" "um-kernel-${RELEASE_VERSION}.deb"

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -205,7 +205,6 @@ initramfs_prepare()
 #
 initramfs_build()
 {
-    local cwd=""
 
     initramfs_prepare
 
@@ -217,14 +216,13 @@ initramfs_build()
         exit 1
     fi
 
-    cwd=$(pwd)
     cd "${KERNEL_BUILD_DIR}"
     "${GEN_INITRAMFS_LIST}" \
         -o "${INITRAMFS_IMG}" \
         -u "${INITRAMFS_ROOT_UID}" \
         -g "${INITRAMFS_ROOT_GID}" \
         "${INITRAMFS_SOURCE}"
-    cd "${cwd}"
+    cd "${CWD}"
 }
 
 kernel_build_command()

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -329,7 +329,8 @@ dtb_build()
     rm -rf "${BOOT_FILE_OUTPUT_DIR}/"*".dtb"
 
     # Build the device trees that we need
-    for dts in $(find dts/ -name '*.dts' -exec basename {} \;); do
+    for dts in "dts/"*".dts"; do
+        dts="$(basename "${dts}")"
         dt="${dts%.dts}"
         echo "Building devicetree blob '${dt}'"
         cpp -nostdinc -undef -D__DTS__ -x assembler-with-cpp \

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -175,9 +175,11 @@ initramfs_prepare()
 
     if [ -n "${INITRAMFS_MODULES_REQUIRED}" ]; then
         mkdir -p "${INITRAMFS_MODULES_DIR}/${KERNEL_RELEASE}"
-        echo -e "\n# kernel modules" >> "${INITRAMFS_DEST}"
-        echo "dir /lib/modules/ 0755 0 0" >> "${INITRAMFS_DEST}"
-        echo "dir /lib/modules/${KERNEL_RELEASE}/ 0755 0 0" >> "${INITRAMFS_DEST}"
+        {
+            echo -e "\n# kernel modules"
+            echo "dir /lib/modules/ 0755 0 0"
+            echo "dir /lib/modules/${KERNEL_RELEASE}/ 0755 0 0"
+        } >> "${INITRAMFS_DEST}"
         add_module_dependencies "${KERNEL_RELEASE}"
     fi
 


### PR DESCRIPTION
Fixed the dependency error for embedding the drivers in the initramfs and refactored to script in preparation for further CI work by boy scouting and fixing 'shellcheck linting errors'. 

shellcheck is a static code analysis 'linting' package for shell scripts.  
To run the latest version always, add the following line (alias) to your ~/.bashrc file: 
`alias shellcheck='docker run -v "$PWD:/mnt" koalaman/shellcheck'`
The pull the shellcheck docker image with: 
`docker pull koalaman/shellcheck`
Now you can check every shellscript on the commandline with: 
`shellcheck [script name]`