### PR TITLE
EMP-366 Additional improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,10 @@ stages:
 
 # Common requisites
 # ==========
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
+  GIT_DEPTH: "1"
+
 .parameters_common: &parameters_common
   tags:
     - docker
@@ -95,8 +99,6 @@ cleanup_build_environment:
 .build_pkg_common: &build_pkg_common
   <<: *parameters_common
   stage: build
-  variables:
-    GIT_SUBMODULE_STRATEGY: recursive
   script:
     - ./build.sh
   artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/debian:stable-slim
+FROM registry.hub.docker.com/library/debian:jessie-slim
 
 LABEL Maintainer="software-embedded-platform@ultimaker.com" \
       Comment="Ultimaker kernel build environment"

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -36,6 +36,7 @@ run_in_docker()
 {
     docker run \
         --rm \
+        -it \
         -u "$(id -u)" \
         -v "$(pwd):${DOCKER_WORK_DIR}" \
         -e "ARCH=${ARCH}" \
@@ -87,7 +88,7 @@ env_check()
 run_build()
 {
     git submodule update --init --recursive
-    run_script "./build.sh"
+    run_script "./build.sh" "${@}"
 }
 
 run_tests()
@@ -148,7 +149,7 @@ if [ "${run_linter}" = "yes" ]; then
     run_linter
 fi
 
-run_build
+run_build "${1-}"
 
 if [ "${run_tests}" = "yes" ]; then
     run_tests

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -104,15 +104,18 @@ run_linter()
 usage()
 {
     echo "Usage: ${0} [OPTIONS]"
-    echo "  -c   Skip run of build environment checks"
+    echo "  -C   Skip run of build environment checks"
     echo "  -h   Print usage"
     echo "  -l   Skip linter of shell scripts"
     echo "  -t   Skip run of tests"
+    echo
+    echo "Other options will be passed on to build.sh"
+    echo "Run './build.sh -h' for more information."
 }
 
-while getopts ":chlt" options; do
+while getopts ":Chlt" options; do
     case "${options}" in
-    c)
+    C)
         run_env_check="no"
         ;;
     h)
@@ -149,7 +152,7 @@ if [ "${run_linter}" = "yes" ]; then
     run_linter
 fi
 
-run_build "${1-}"
+run_build "${@}"
 
 if [ "${run_tests}" = "yes" ]; then
     run_tests

--- a/run_linter.sh
+++ b/run_linter.sh
@@ -35,7 +35,7 @@ run_shellcheck()
     fi
 
     SCRIPTS="$(find "./scripts/" "./test/" -name '*.sh')"
-    for shellcheck_script in "./"*".sh"  "./legacy_test/"*".sh" ${SCRIPTS}; do
+    for shellcheck_script in "./"*".sh" ${SCRIPTS}; do
         if [ ! -r "${shellcheck_script}" ]; then
             echo "--------------------------------------------------------------------------------"
             echo "Warning, skipping shellcheck '${shellcheck_script}'."


### PR DESCRIPTION
Addresses suggestions from @raysiudak.

 - Docker now uses Debian jessie.
 - Made Git variables global.
 - Instruct Gitlab to shallowly clone. (EMP-646)
 - Don't lint non-existent legacy-tests.

Pass on arguments to build.sh

 - Docker needs to run with an interactive terminal (-it) for menuconfig to work.