### PR TITLE
EMP 645 Improve CI docker logic

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,19 +48,28 @@ lint_test_scripts:
 .build_environment_common: &build_environment_common
   <<: *parameters_common
   image: registry.hub.docker.com/library/docker:stable
+  before_script:
+    - |
+      apk update && apk add git
 
 prepare_build_environment:
   <<: *build_environment_common
-  only:
-    <<: *changes_docker
   stage: prepare
   script:
-    - docker build --rm -t "${CI_COMMIT_SHA}:${CI_PIPELINE_ID}" .
     - |
+      if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
+        echo "Dockerfile changes detected..."
+        docker build --rm -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" .
         docker run \
         --rm \
         "$CI_COMMIT_SHA:$CI_PIPELINE_ID" \
         /test/buildenv_check.sh
+      else
+        echo "No Dockerfile changes..."
+        docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
+        docker tag "${CI_REGISTRY_IMAGE}:latest" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+        docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+      fi
 
 # The push to the Docker registry is thus only executed when docker changes are
 # performed and the working branch is 'master'
@@ -72,22 +81,24 @@ push_build_environment:
       - master
   stage: push
   script:
-    - docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
-    - docker tag  "${CI_COMMIT_SHA}:${CI_PIPELINE_ID}" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-    - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-    - docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
-    - docker push "${CI_REGISTRY_IMAGE}:latest"
+    - |
+      docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
+      docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
+      docker push "${CI_REGISTRY_IMAGE}:latest"
 
 cleanup_build_environment:
   <<: *build_environment_common
-  only:
-    <<: *changes_docker
   stage: cleanup
+  except:
+    refs:
+      - master
   when: always
   script:
     - |
-      if docker inspect --type image "${CI_COMMIT_SHA}:${CI_PIPELINE_ID}" 1> /dev/null; then
-        docker rmi "${CI_COMMIT_SHA}:${CI_PIPELINE_ID}"
+      if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
+        if docker inspect --type image "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" 1> /dev/null; then
+          docker rmi "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+        fi
       fi
 
 # Package generation
@@ -105,38 +116,24 @@ cleanup_build_environment:
       - ./*.deb
     expire_in: 3 days
 
-.dev_docker_candidate: &dev_docker_candidate
+.docker_branch: &docker_branch
   except:
     refs:
       - master
-  only:
-    <<: *changes_docker
-  image: "${CI_COMMIT_SHA}:${CI_PIPELINE_ID}"
+  image: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
 
-.dev_docker_latest: &dev_docker_latest
-  except:
-    <<: *changes_docker
-    refs:
-      - master
-  image: "${CI_REGISTRY_IMAGE}:latest"
-
-.master_docker_latest: &master_docker_latest
+.docker_master: &docker_master
   only:
     refs:
       - master
   image: "${CI_REGISTRY_IMAGE}:latest"
 
   # Build the package on a non-master branch in a modified Docker image.
-build:dev_docker_candidate:
+build:branch:
   <<: *build_pkg_common
-  <<: *dev_docker_candidate
-
-# Build the package on a non-master branch in the latest Docker image.
-build:dev_docker_latest:
-  <<: *build_pkg_common
-  <<: *dev_docker_latest
+  <<: *docker_branch
 
 # Build the package on the master branch in the latest Docker image.
-build:master_docker_latest:
+build:master:
   <<: *build_pkg_common
-  <<: *master_docker_latest
+  <<: *docker_master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,11 @@ lint_scripts_test:
   script:
     - find 'test/' -iname '*.sh' -exec shellcheck -x -C -f tty {} \;
 
+lint_scripts_ci:
+  <<: *lint_scripts_common
+  script:
+    - find 'ci/' -iname '*.sh' -exec shellcheck -x -C -f tty {} \;
+
 # Prepare stage
 # =============
 prepare_environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,20 +60,7 @@ prepare_environment:
   <<: *environment_common
   stage: prepare
   script:
-    - |
-      if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
-        echo "Dockerfile changes detected..."
-        docker build --rm -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" .
-        docker run \
-        --rm \
-        "$CI_COMMIT_SHA:$CI_PIPELINE_ID" \
-        /test/buildenv_check.sh
-      else
-        echo "No Dockerfile changes..."
-        docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
-        docker tag "${CI_REGISTRY_IMAGE}:latest" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-        docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-      fi
+    - ci/prepare_environment.sh
 
 # Push stage
 # ==========
@@ -85,10 +72,7 @@ push_environment:
       - master
   stage: push
   script:
-    - |
-      docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
-      docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
-      docker push "${CI_REGISTRY_IMAGE}:latest"
+    - ci/push_environment.sh
 
 # Build stage
 # ===========
@@ -132,9 +116,4 @@ cleanup_environment:
       - master
   when: always
   script:
-    - |
-      if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
-        if docker inspect --type image "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" 1> /dev/null; then
-          docker rmi "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-        fi
-      fi
+    - ci/cleanup_environment.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,6 @@ push_environment:
 .build_common: &build_common
   <<: *jobs_common
   stage: build
-EMP-645_improve_ci_docker_logic
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     GIT_DEPTH: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,9 +25,7 @@ stages:
 # ======================================================
 .environment_common: &environment_common
   <<: *jobs_common
-  image: registry.hub.docker.com/library/docker:stable
-  before_script:
-    - apk update && apk add git
+  image: registry.hub.docker.com/library/docker:stable-git
 
 # The following can be included in the 'only', or 'except' statements,
 # so they look for changes in files related to Docker and thus our environment.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,47 +13,51 @@ stages:
   - prepare
   - push
   - build
-  # - test
   - cleanup
 
-# Common requisites
-# ==========
-.parameters_common: &parameters_common
+# Common parameters to be included in every job
+# =============================================
+.jobs_common: &jobs_common
   tags:
     - docker
 
-.changes_docker: &changes_docker
+# Common parameters used in all environment related jobs
+# ======================================================
+.environment_common: &environment_common
+  <<: *jobs_common
+  image: registry.hub.docker.com/library/docker:stable
+  before_script:
+    - apk update && apk add git
+
+# The following can be included in the 'only', or 'except' statements,
+# so they look for changes in files related to Docker and thus our environment.
+.environment_common_docker_changes: &environment_common_docker_changes
   changes:
     - Dockerfile
     - .dockerignore
     - dockerfiles/**/*
 
-.shell_linting_common: &shell_linting_common
-  <<: *parameters_common
+# Lint stage
+# =============
+.lint_scripts_common: &lint_scripts_common
+  <<: *jobs_common
   image: registry.hub.docker.com/koalaman/shellcheck-alpine:stable
   stage: lint
 
-lint_build_scripts:
-  <<: *shell_linting_common
+lint_scripts_build:
+  <<: *lint_scripts_common
   script:
     - shellcheck -C -f tty "build"*".sh"
 
-lint_test_scripts:
-  <<: *shell_linting_common
+lint_scripts_test:
+  <<: *lint_scripts_common
   script:
     - find 'test/' -iname '*.sh' -exec shellcheck -x -C -f tty {} \;
 
-# Environment (Docker)
-# ====================
-.build_environment_common: &build_environment_common
-  <<: *parameters_common
-  image: registry.hub.docker.com/library/docker:stable
-  before_script:
-    - |
-      apk update && apk add git
-
-prepare_build_environment:
-  <<: *build_environment_common
+# Prepare stage
+# =============
+prepare_environment:
+  <<: *environment_common
   stage: prepare
   script:
     - |
@@ -71,12 +75,12 @@ prepare_build_environment:
         docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
       fi
 
-# The push to the Docker registry is thus only executed when docker changes are
-# performed and the working branch is 'master'
-push_build_environment:
-  <<: *build_environment_common
+# Push stage
+# ==========
+push_environment:
+  <<: *environment_common
   only:
-    <<: *changes_docker
+    <<: *environment_common_docker_changes
     refs:
       - master
   stage: push
@@ -86,8 +90,42 @@ push_build_environment:
       docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
       docker push "${CI_REGISTRY_IMAGE}:latest"
 
-cleanup_build_environment:
-  <<: *build_environment_common
+# Build stage
+# ===========
+.build_common: &build_common
+  <<: *jobs_common
+  stage: build
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+    GIT_DEPTH: 1
+  script:
+    - ./build.sh
+  artifacts:
+    name: "$CI_COMMIT_REF_NAME-$CI_COMMIT_SHA"
+    paths:
+      - ./*.deb
+    expire_in: 3 days
+
+# Build the package on a non-master branch in a modified Docker image.
+build_branch:
+  <<: *build_common
+  except:
+    refs:
+      - master
+  image: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+
+# Build the package on the master branch in the latest Docker image.
+build_master:
+  <<: *build_common
+  only:
+    refs:
+      - master
+  image: "${CI_REGISTRY_IMAGE}:latest"
+
+# Cleanup stage
+# =============
+cleanup_environment:
+  <<: *environment_common
   stage: cleanup
   except:
     refs:
@@ -100,40 +138,3 @@ cleanup_build_environment:
           docker rmi "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
         fi
       fi
-
-# Package generation
-# ==================
-.build_pkg_common: &build_pkg_common
-  <<: *parameters_common
-  stage: build
-  variables:
-    GIT_SUBMODULE_STRATEGY: recursive
-  script:
-    - ./build.sh
-  artifacts:
-    name: "$CI_COMMIT_REF_NAME-$CI_COMMIT_SHA"
-    paths:
-      - ./*.deb
-    expire_in: 3 days
-
-.docker_branch: &docker_branch
-  except:
-    refs:
-      - master
-  image: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-
-.docker_master: &docker_master
-  only:
-    refs:
-      - master
-  image: "${CI_REGISTRY_IMAGE}:latest"
-
-  # Build the package on a non-master branch in a modified Docker image.
-build:branch:
-  <<: *build_pkg_common
-  <<: *docker_branch
-
-# Build the package on the master branch in the latest Docker image.
-build:master:
-  <<: *build_pkg_common
-  <<: *docker_master

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ BOOT_FILE_OUTPUT_DIR="${DEBIAN_DIR}/boot"
 INITRAMFS_MODULES_REQUIRED="sunxi_wdt.ko ssd1307fb.ko drm.ko sun4i-backend.ko sun4i-drm.ko sun4i-tcon.ko sun4i-drm-hdmi.ko sun4i-hdmi-i2c.ko"
 INITRAMFS_SOURCE="${INITRAMFS_SOURCE:-initramfs/initramfs.lst}"
 
-BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.29.3-r10.apk"
+BB_PKG="http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/armhf/busybox-static-1.30.1-r2.apk"
 BB_BIN="busybox"
 
 DEPMOD="${DEPMOD:-/sbin/depmod}"

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -36,6 +36,7 @@ run_in_docker()
 {
     docker run \
         --rm \
+        -it \
         -u "$(id -u)" \
         -v "$(pwd):${DOCKER_WORK_DIR}" \
         -e "ARCH=${ARCH}" \

--- a/ci/cleanup_environment.sh
+++ b/ci/cleanup_environment.sh
@@ -4,3 +4,4 @@ if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.do
     docker rmi "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
   fi
 fi
+exit 0

--- a/ci/cleanup_environment.sh
+++ b/ci/cleanup_environment.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
+  if docker inspect --type image "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" 1> /dev/null; then
+    docker rmi "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+  fi
+fi

--- a/ci/prepare_environment.sh
+++ b/ci/prepare_environment.sh
@@ -3,9 +3,9 @@ if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.do
   echo "Dockerfile changes detected..."
   docker build --rm -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" .
   docker run --rm "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "/test/buildenv_check.sh"
-else
-  echo "No Dockerfile changes..."
-  docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
-  docker tag "${CI_REGISTRY_IMAGE}:latest" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
-  docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+  exit 0
 fi
+
+echo "No Dockerfile changes..."
+docker tag "${CI_REGISTRY_IMAGE}:latest" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+exit 0

--- a/ci/prepare_environment.sh
+++ b/ci/prepare_environment.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
+  echo "Dockerfile changes detected..."
+  docker build --rm -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" .
+  docker run --rm "$CI_COMMIT_SHA:$CI_PIPELINE_ID" "/test/buildenv_check.sh"
+else
+  echo "No Dockerfile changes..."
+  docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
+  docker tag "${CI_REGISTRY_IMAGE}:latest" "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+  docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+fi

--- a/ci/prepare_environment.sh
+++ b/ci/prepare_environment.sh
@@ -2,7 +2,7 @@
 if git whatchanged --name-only --pretty="" master...HEAD | grep "Dockerfile\|.dockerignore"; then
   echo "Dockerfile changes detected..."
   docker build --rm -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" .
-  docker run --rm "$CI_COMMIT_SHA:$CI_PIPELINE_ID" "/test/buildenv_check.sh"
+  docker run --rm "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "/test/buildenv_check.sh"
 else
   echo "No Dockerfile changes..."
   docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"

--- a/ci/push_environment.sh
+++ b/ci/push_environment.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
+docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
+docker push "${CI_REGISTRY_IMAGE}:latest"

--- a/ci/push_environment.sh
+++ b/ci/push_environment.sh
@@ -2,3 +2,4 @@
 docker login -u gitlab-ci-token -p "${CI_JOB_TOKEN}" "${CI_REGISTRY}"
 docker tag  "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}" "${CI_REGISTRY_IMAGE}:latest"
 docker push "${CI_REGISTRY_IMAGE}:latest"
+exit 0

--- a/run_linter.sh
+++ b/run_linter.sh
@@ -7,7 +7,7 @@
 set -eu
 
 DOCKER_WORK_DIR="${DOCKER_WORK_DIR:-/build}"
-SHELLCHECK_ARGS="-x -C -f tty"
+SHELLCHECK_ARGS="shellcheck -x -C -f tty"
 
 usage()
 {
@@ -28,7 +28,7 @@ run_shellcheck()
             --rm \
             -v \"$(pwd):${DOCKER_WORK_DIR}\" \
             -w \"${DOCKER_WORK_DIR}\" \
-            registry.hub.docker.com/koalaman/shellcheck:stable"
+            registry.hub.docker.com/koalaman/shellcheck-alpine:stable"
     else
         echo "You need Docker to run the shellcheck linter."
         return

--- a/run_linter.sh
+++ b/run_linter.sh
@@ -34,8 +34,8 @@ run_shellcheck()
         return
     fi
 
-    SCRIPTS="$(find "./scripts/" "./test/" -name '*.sh')"
-    for shellcheck_script in "./"*".sh"  "./legacy_test/"*".sh" ${SCRIPTS}; do
+    SCRIPTS="$(find "./scripts/" "./test/" "./ci/" -name '*.sh')"
+    for shellcheck_script in "./"*".sh" ${SCRIPTS}; do
         if [ ! -r "${shellcheck_script}" ]; then
             echo "--------------------------------------------------------------------------------"
             echo "Warning, skipping shellcheck '${shellcheck_script}'."


### PR DESCRIPTION
Previously, a Docker image was rebuilt by rules specified in 'only'.

This caused a situation where a build with an updated Dockerfile would
succeed once, since Gitlab bases this rule on the previous commit.
A subsequent build would thus use the master branch Dockerfile,
since there were no changes according to Gitlab.

We decided that space on our runner (Dave) is more precious than CPU
power. So when a branch has a modified Dockerfile, Dave will rebuild
the Docker image for every build.

Since this behavior is not supported by Gitlab by default, we will
implement it using scripts. This causes build steps to show up in the
Gitlab interface, even though they don't do anything. This was
considered acceptable.

Signed-off-by: martijnbruinenberg <m.bruinenberg@ultimaker.com>