### PR TITLE
[EMP-877] Fix symbols not found while loading framebuffer modules in initrd

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -160,7 +160,9 @@ enable_framebuffer_device()
 {
     echo "Enable frame-buffer driver."
 
-    modules="sun4i-drm-hdmi sun4i-hdmi-i2c sun4i-tcon sun4i-backend sun4i-drm"
+    modules="drm rc_core cec fb_sys_fops cfbfillrect syscopyarea cfbimgblt sysfillrect \
+             sysimgblt cfbcopyarea drm_kms_helper sun4i_drm_hdmi sun4i-drm-hdmi sun4i-hdmi-i2c \
+             sun4i-tcon sun4i-backend sun4i-drm"
     for module in ${modules}; do
         if ! probe_module "${module}"; then
             echo "Error, registering framebuffer device."


### PR DESCRIPTION
This is not a problem, it is just the modprobe tool telling us
that its missing dependencies. These are in turn resolved impplicitely
by depmod, making sure the dependent modules are loaded. This is
only visible because we use modprobe with the verbose flag.

This is fixed by making the module inclusion explicit and in the
right order.

Fixes EMP-877.

Signed-off-by: Raymond Siudak <r.siudak@ultimaker.com>