### PR TITLE
[CES-974] - Fix device tree entry for the ultiboard eeprom.

### DIFF
--- a/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
+++ b/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
@@ -101,10 +101,7 @@
     carrierdata@57 {
         compatible = "atmel,24c32";
         reg = <0x57>;
-        pinctrl-names = "default";
-        pinctrl-0 = <&pinctrl_gpio4>;
         pagesize = <32>;
-        wp-gpios = <&gpio4 10 0>;
     };
 };
 


### PR DESCRIPTION
**Problem:** When booting the system, we see this error message:

at24 1-0057: Error applying setting, reverse things back
at24: probe of 1-0057 failed with error -22

**Cause:** In the 1-0057 eeprom (in ultiboard) device tree entry, we have some invalid configuration which blocks the driver from proper configuring the device.
Actually this configuration is only allowed in newer version of the eeprom driver (starting in kernel 4.19.xxx) and we using the kernel 4.14.98.

@dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts

```
&i2c2 {
    /* Carrier data EEPROM (U12) */
    carrierdata@57 {
        compatible = "atmel,24c32";
        reg = <0x57>;
        pinctrl-names = "default"         // Not allowed (invalid)
        pinctrl-0 = <&pinctrl_gpio4>;     // Not allowed (invalid)
        pagesize = <32>;
        wp-gpios = <&gpio4 10 0>;         // Not allowed (invalid)
    };
};
```

**Solution:** Remove invalid configuration.