### PR TITLE
[CES-1232] Fix Frame Leds and Panel backlight in the device free.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -166,7 +166,7 @@ initramfs_add_modules()
             for dependency in ${dependencies}; do
                 dep_module="$(basename "${dependency}")"
                 echo "Adding dependency: '${dep_module}' for module: '${module}'"
-                if [ -n "${INITRAMFS_MODULES##*${dep_module}*}" ]; then
+                if [ -n "${INITRAMFS_MODULES##*"${dep_module}"*}" ]; then
                     INITRAMFS_MODULES="${INITRAMFS_MODULES} ${dep_module}"
                 fi
             done

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -48,17 +48,6 @@ run_in_docker()
         "${@}"
 }
 
-run_in_shell()
-{
-    ARCH="${ARCH}" \
-    PREFIX="${PREFIX}" \
-    RELEASE_VERSION="${RELEASE_VERSION}" \
-    CROSS_COMPILE="${CROSS_COMPILE}" \
-    INITRAMFS_SOURCE="${INITRAMFS_SOURCE}" \
-    DEPMOD="${DEPMOD}" \
-    eval "${@}"
-}
-
 env_check()
 {
     run_in_docker "./docker_env/buildenv_check.sh"

--- a/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
+++ b/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
@@ -47,7 +47,7 @@
 };
 
 &pinctrl_gpio4 {
-	fsl,pins = <
+    fsl,pins = <
         MX8MM_IOMUXC_SAI3_RXC_GPIO4_IO29        0x140 /* GPIO4*/
         MX8MM_IOMUXC_SAI1_RXC_GPIO4_IO1         0x100 /* GPIO7 / RESET_HUB*/
         MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28       0x080 /* GPIO6 / IMXRT BootMode Enable*/       
@@ -60,7 +60,7 @@
         MX8MM_IOMUXC_SAI1_TXD5_GPIO4_IO17       0x140 /* BOOT_SEL1# */
         MX8MM_IOMUXC_SAI1_TXD6_GPIO4_IO18       0x140 /* BOOT_SEL2# */
         MX8MM_IOMUXC_SAI1_RXD5_GPIO4_IO7        0x080 /* SAI1_RXD5 -> RESET_OUT# / IMXRT nReset */
-	>;
+    >;
 };
 
 &pinctrl_gpio5 {
@@ -118,6 +118,36 @@
                           "VCC24_HP_PG", "VCC24_MOT_PG", "LVDS_PWR_EN", "LVDS_PWR_OK", 
                           "SAFETY_BTN_STATUS", "SAFETY_RESET", "VCC24_PH_EN", "VCC24_MOT_EN";
     };
+    
+    cabin_light: pca9632@61 {
+        compatible = "nxp,pca9632";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reg = <0x61>;
+        nxp,totem-pole;
+        nxp,inverted-out;
+        nxp,hw-blink;
+        red@0 {
+            label = "red:cabin_light";
+            reg = <0>;
+            linux,default-trigger = "none";
+        };
+        green@1 {
+            label = "green:cabin_light";
+            reg = <1>;
+            linux,default-trigger = "none";
+        };
+        blue@2 {
+            label = "blue:cabin_light";
+            reg = <2>;
+            linux,default-trigger = "none";
+        };
+        white@3 {
+            label = "white:cabin_light";
+            reg = <3>;
+            linux,default-trigger = "default-on";
+        };
+    };
 };
 
 /* Set pin names for IMXRT control lines */
@@ -160,11 +190,11 @@
             gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
             linux,default-trigger = "mmc1";
             default-state = "keep";
-		};
-	};
+        };
+    };
 
-	gpio-keys {
-	   status = "disabled";
-	};
+    gpio-keys {
+       status = "disabled";
+    };
 };
 

--- a/dts/ulticontroller4.0.dtsi
+++ b/dts/ulticontroller4.0.dtsi
@@ -25,31 +25,30 @@
         gpio-line-names = "BUZZER_EN", "DOOR", "DISP_RST", "TOUCH_RST";
     };
 
-    pca9632: pca9632 {
+    panel_lights: pca9632@60 {
         compatible = "nxp,pca9632";
         #address-cells = <1>;
         #size-cells = <0>;
         reg = <0x60>;
         nxp,totem-pole;
         nxp,hw-blink;
-
-        led0@0 {
-            label = "unused0";
+        red@0 {
+            label = "red:panel_indicator";
             reg = <0>;
             linux,default-trigger = "none";
         };
-        led1@1 {
-            label = "unused1";
+        green@1 {
+            label = "green:panel_indicator";
             reg = <1>;
             linux,default-trigger = "none";
         };
-        led2@2 {
-            label = "unused2";
+        blue@2 {
+            label = "blue:panel_indicator";
             reg = <2>;
             linux,default-trigger = "none";
         };
         panel_backlight: backlight@3 {
-            label = "backlight";
+            label = "white:panel_backlight";
             reg = <3>;
             linux,default-trigger = "default-on";
         };


### PR DESCRIPTION
This ticket  turned out to be 2 problems:

1) The reported error messages were related to the Display (screen) backlight, not to the Frame Leds. 

The problem was the name of the device: it was pca963x:backlight and the LedService was expecting pca963x:white:panel_backlight as in S5. The solution was renaming it in the device tree, so keeping the same name convention as S-Line.

2) The Frame LED Strip was indeed not working.

The device was not exposed in the device tree. After exposing it and using the naming convention expected by Opinicus, it works as expected.