### PR TITLE
E1-989 Show a blinking LED at the end of the update/restore procedure

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -78,8 +78,22 @@ restart()
     shutdown
 }
 
+led()
+{
+    # Blink LED (if exists) for the given action
+    ACTION="${1}"
+
+    LED_FILE_TRIGGER="/sys/class/leds/a20-olinuxino-lime2:green:usr/trigger"
+    if [ -f "${LED_FILE_TRIGGER}" ]; then
+      echo "${ACTION}" > "${LED_FILE_TRIGGER}"
+    fi
+}
+
 restore_complete_loop()
 {
+    # Blink LED (if exists) to show we are ready
+    led "heartbeat"
+
     while true; do
     	echo "Restore complete, remove the recovery SD card and powercycle the printer."
     	sleep 30s
@@ -189,6 +203,9 @@ find_and_run_update()
     if isBootingRestoreImage; then
         SOFTWARE_INSTALL_MODE="restore"
     fi
+
+    # Blink LED for internal FLASH memory access
+    led "mmc1"
 
     echo "Checking for updates ..."
     for dev in ${UPDATE_DEVICES}; do


### PR DESCRIPTION
The Olimex board has a green LED which until now was configured (in the device tree) to be always on.
This PR changes the LED to blink in a pattern of fast-fast-pause to 
indicate to the user that the update is finished. When the update/restore 
procedure has finished.
During the update, the LED will flash on access to the eMMC program memory.

This has the advantage that the feedback works, even without attached display.
Important for the NFC Programming Station where the display currently is not 
supported by the jedi-systemupdate package.