### PR TITLE
[MISP-2343] Update Initramfs Splash Screen

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,16 +10,36 @@ include:
 
 .retrieve_source:
   before_script:
-    - git -c submodule.linux.url="https://ultimaker-ci:${CI_PERSONAL_ACCESS_TOKEN}@github.com/Ultimaker/linux" submodule update --init --recursive
-    - git -c submodule.drivers.net.wireless.realtek.rtl8822ce.url="https://ultimaker-ci:${CI_PERSONAL_ACCESS_TOKEN}@github.com/Ultimaker/rtl8822ce" submodule update --init --recursive
+    - git clone --branch  ${CI_COMMIT_REF_NAME} ${CI_REPOSITORY_URL} --depth=1
+    - git -c submodule.linux.url="https://ultimaker-ci:${CI_PERSONAL_ACCESS_TOKEN}@github.com/Ultimaker/linux" submodule update --init --depth 1
+    - cd linux
+    - git -c submodule.drivers/net/wireless/realtek/rtl8822ce.url="https://ultimaker-ci:${CI_PERSONAL_ACCESS_TOKEN}@github.com/Ultimaker/rtl8822ce" submodule update --init --depth 1   
+    - cd ..
 
+# Overriding prime-jedi 'prepare_environment'.
+# Prevents execution of source retrieval steps which cannot handle submodules not in GitLab
+prepare_environment:
+  image: "registry.hub.docker.com/library/docker:stable-git"
+  extends:
+    - .jobs_common
+    - .retrieve_source
+    
 # Build stage
 # ===========
 build:
-  timeout: 2h
+  image: "${BUILD_PIPELINE_IMAGE}"
   extends:
+    - .jobs_common
     - .retrieve_source
+
+test:
+  image: "${BUILD_PIPELINE_IMAGE}"
+  extends: 
+    - .jobs_common  
   script:
-    - ci/add_private_key.sh
-    - ./build.sh
-    - cp -v ./_build*/*.deb "./"
+    - echo "Tests not implemented!"
+    
+cleanup_environment:
+  image: "registry.hub.docker.com/library/docker:stable-git"
+  extends:
+    - .jobs_common

--- a/build.sh
+++ b/build.sh
@@ -168,7 +168,7 @@ initramfs_add_modules()
             for dependency in ${dependencies}; do
                 dep_module="$(basename "${dependency}")"
                 echo "Adding dependency: '${dep_module}' for module: '${module}'"
-                if [ -n "${INITRAMFS_MODULES##*${dep_module}*}" ]; then
+                if [ -n "${INITRAMFS_MODULES##*"${dep_module}"*}" ]; then
                     INITRAMFS_MODULES="${INITRAMFS_MODULES} ${dep_module}"
                 fi
             done

--- a/build_for_ultimaker.sh
+++ b/build_for_ultimaker.sh
@@ -50,17 +50,6 @@ run_in_docker()
         "${@}"
 }
 
-run_in_shell()
-{
-    ARCH="${ARCH}" \
-    PREFIX="${PREFIX}" \
-    RELEASE_VERSION="${RELEASE_VERSION}" \
-    CROSS_COMPILE="${CROSS_COMPILE}" \
-    INITRAMFS_SOURCE="${INITRAMFS_SOURCE}" \
-    DEPMOD="${DEPMOD}" \
-    eval "${@}"
-}
-
 env_check()
 {
     run_in_docker "./docker_env/buildenv_check.sh"

--- a/docker_env/Dockerfile
+++ b/docker_env/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         gcc \
         gcc-arm-linux-gnueabihf \
         gettext \
+        git \
         fakeroot \
         kmod \
         libssl-dev \

--- a/run_shellcheck.sh
+++ b/run_shellcheck.sh
@@ -1,5 +1,44 @@
 #!/bin/sh
-echo "SHELLCHECK disabled"
-# Because of prime-jedi, this script is required.
-# Shellcheck _is_ performed during a later stage!
-# ./run.sh shellcheck
+# ! run_shellcheck.sh has to be sh, not bash as the docker image that runs it does not
+# include bash
+#
+# Copyright (C) 2019-2022 Ultimaker B.V.
+#
+
+# This script is mandatory in a repository, to make sure the shell scripts are correct and of good quality.
+
+set -eu
+
+SHELLCHECK_FAILURE="false"
+
+# Add your scripts or search paths here
+SHELLCHECK_PATHS=" \
+*.sh \
+./docker_env/*.sh \
+ci/*.sh \
+initramfs/*.sh
+"
+
+# shellcheck disable=SC2086
+SCRIPTS="$(find ${SHELLCHECK_PATHS} -name '*.sh')"
+
+for script in ${SCRIPTS}; do
+    if [ ! -r "${script}" ]; then
+        echo_line
+        echo "WARNING: skipping shellcheck for '${script}'."
+        echo_line
+        continue
+    fi
+
+    echo "Running shellcheck on '${script}'"
+    shellcheck -x -C -f tty "${script}" || SHELLCHECK_FAILURE="true"
+done
+
+if [ "${SHELLCHECK_FAILURE}" = "true" ]; then
+    echo "WARNING: One or more scripts did not pass shellcheck."
+    exit 1
+fi
+
+echo "All scripts passed shellcheck."
+
+exit 0


### PR DESCRIPTION
Change how the init.sh shows a splash screen.
Instead of checking the BOM number and display a picture embedded in the initramfs, it will always display the same picture stored in the /boot partition. It will be responsibility of another service (u-boot-splash-screen) to update this picture in the /boot partition.
The picture must be in the framebuffer format with the name: `umsplash-800x320.fb`