### PR TITLE
MISP-2347: Remove build step from gitlab ci config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,12 +6,3 @@ include:
   - project: ultimaker/embedded/prime-jedi
     ref: master
     file: /gitlab_ci_templates/jedi-gitlab-ci-template.yml
-
-# Build stage
-# ===========
-build:
-  timeout: 2h
-  script:
-    - ci/add_private_key.sh
-    - ./build.sh
-    - cp -v ./_build*/*.deb "./"


### PR DESCRIPTION
The build step in the gitlab-ci config file was overriding the one from prime-jedi, which uses the correct version tag for packages released to Cloudsmith.