### PR TITLE
Fix failing shellcheck

### DIFF
--- a/docker_env/buildenv_check.sh
+++ b/docker_env/buildenv_check.sh
@@ -97,6 +97,7 @@ check_library_installation()
     done
 }
 
+# shellcheck disable=SC2317
 cleanup()
 {
        if [ "$(dirname "${TEST_DIR}")" != "/tmp" ]; then


### PR DESCRIPTION
After a recent release of shellcheck, it starts complaining about code that might not be reacheable, like function called from trap. So it is safe to ignore if a fuction is called from trap like the cleanup() is.