### PR TITLE
SEM-146 Make printers country code lockable in production

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -220,6 +220,32 @@ isBootingRestoreImage()
 
 check_and_set_eeprom_data()
 {
+    # The printer's mainboard EEPROM can be "provisioned" by inserting a USB drive during boot.
+    # The USB drive must contain a single ext4 partition, containing one or more of the following
+    # files:
+    #
+    # - article_number
+    #   A single-line text file, containing the printer's BOM number in hex notation, exactly 4 bytes.
+    #   For instance, for an S5R2 printer, the file should contain the following line:
+    #       0x00 0x03 0x45 0xCB
+    #   (this is equivalent to decimal 214475).
+    #
+    # - country_code_lock
+    #   A single line text file, containing the printer's locked country code, in hex notation,
+    #   exactly 2 bytes.
+    #   For instance, to lock the printer to the AU country code, the file should contain the line:
+    #     0x41 0x55
+    #   To clear the lock, the file should contain:
+    #     0xFF 0xFF
+    #
+    # If either of these files is missing, no data is written to that part of the EEPROM.
+    #
+    # Relevant EEPROM layout here:
+    # (See opinicus for full details on EEPROM layout)
+    #   0x0100 - 0x0104     BOM number / article number
+    #   ...
+    #   0x0118 - 0x0120     Locked country code
+
     dev="/dev/sda1"
     article_number_file="${PROVISIONING_USB_MOUNT}/article_number"
     country_code_lock_file="${PROVISIONING_USB_MOUNT}/country_code_lock"

--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -258,51 +258,41 @@ check_and_set_eeprom_data()
     country_code_lock=$(i2ctransfer -y 3 w2@0x57 0x01 0x18 r2)
     echo "--> Country code lock read from EEPROM: >${country_code_lock}<"
 
-
+    # Wait for the USB drive to become visible; max 5 seconds.
     retries=5
-    while [ "${retries}" -gt 0 ]; do
-        if [ ! -b "${dev}" ]; then
-            retries="$((retries - 1))"
-            sleep 1
-            continue
-        fi
-
-        echo "Attempting to mount '${dev}'."
-        if ! mount -t f2fs,ext4,vfat,auto -o exec,noatime "${dev}" "${PROVISIONING_USB_MOUNT}"; then
-            return 0
-        fi
-
-        if [ ! -r "${article_number_file}" ] && [ ! -r "${country_code_lock_file}" ]; then
-            umount "${dev}"
-            echo "No article number file or country code lock file found on '${dev}', skipping."
-            return 0
-        fi
-
-        if [ -r "${article_number_file}" ]; then
-            article_number="$(cat "${article_number_file}")"
-            echo "Trying to write article nr: '${article_number}'."
-            # shellcheck disable=SC2086
-            if ! i2ctransfer -y 3 w6@0x57 0x01 0x00 ${article_number}; then
-                umount "${dev}"
-                echo "Failed to write article number to EEPROM, skipping."
-                return 0
-            fi
-        fi
-
-        if [ -r "${country_code_lock_file}" ]; then
-            country_code="$(cat "${country_code_lock_file}")"
-            echo "Trying to write country code lock: '${country_code}'."
-            # shellcheck disable=SC2086
-            if ! i2ctransfer -y 3 w4@0x57 0x01 0x18 ${country_code}; then
-                umount "${dev}"
-                echo "Failed to write country code lock to EEPROM, skipping."
-                return 0
-            fi
-        fi
-
-        umount "${dev}"
-        retries=0
+    while [ ! -b "${dev}" ] && [ "${retries}" -gt 0 ]; do
+        retries="$((retries - 1))"
+        sleep 1
     done
+
+    echo "Attempting to mount '${dev}'."
+    if ! mount -t f2fs,ext4,vfat,auto -o exec,noatime "${dev}" "${PROVISIONING_USB_MOUNT}"; then
+        return 0
+    fi
+
+    if [ -r "${article_number_file}" ]; then
+        article_number="$(cat "${article_number_file}")"
+        echo "Trying to write article nr: '${article_number}'."
+        # shellcheck disable=SC2086
+        if ! i2ctransfer -y 3 w6@0x57 0x01 0x00 ${article_number}; then
+            echo "Failed to write article number to EEPROM, skipping."
+        fi
+    else
+        echo "No article number file ${article_number_file} found, skipping."
+    fi
+
+    if [ -r "${country_code_lock_file}" ]; then
+        country_code="$(cat "${country_code_lock_file}")"
+        echo "Trying to write country code lock: '${country_code}'."
+        # shellcheck disable=SC2086
+        if ! i2ctransfer -y 3 w4@0x57 0x01 0x18 ${country_code}; then
+            echo "Failed to write country code lock to EEPROM, skipping."
+        fi
+    else
+        echo "No country code lock file ${country_code_lock_file} found, skipping."
+    fi
+
+    umount "${dev}"
 }
 
 find_and_run_update()

--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -12,7 +12,7 @@ ROOT_MOUNT="/mnt/root"
 UPDATE_IMAGE="um-update.swu"
 UPDATE_IMG_MOUNT="/mnt/update_img"
 UPDATE_SRC_MOUNT="/mnt/update"
-ARTICLENR_USB_MOUNT="/mnt/usb"
+PROVISIONING_USB_MOUNT="/mnt/usb"
 RESCUE_SHELL="no"
 
 PREFIX="${PREFIX:-/usr/}"
@@ -218,14 +218,19 @@ isBootingRestoreImage()
     findfs LABEL=recovery_data 
 }
 
-check_and_set_article_number()
+check_and_set_eeprom_data()
 {
     dev="/dev/sda1"
-    article_number_file="${ARTICLENR_USB_MOUNT}/article_number"
+    article_number_file="${PROVISIONING_USB_MOUNT}/article_number"
+    country_code_lock_file="${PROVISIONING_USB_MOUNT}/country_code_lock"
 
-    #Get the article number from EEPROM
+    # Get the article number from EEPROM
     art_num=$(i2ctransfer -y 3 w2@0x57 0x01 0x00 r4)
     echo "---> Article number read from EEPROM: >${art_num}<"
+
+    # Get the country code lock from EEPROM
+    country_code_lock=$(i2ctransfer -y 3 w2@0x57 0x01 0x18 r2)
+    echo "--> Country code lock read from EEPROM: >${country_code_lock}<"
 
 
     retries=5
@@ -237,23 +242,36 @@ check_and_set_article_number()
         fi
 
         echo "Attempting to mount '${dev}'."
-        if ! mount -t f2fs,ext4,vfat,auto -o exec,noatime "${dev}" "${ARTICLENR_USB_MOUNT}"; then
+        if ! mount -t f2fs,ext4,vfat,auto -o exec,noatime "${dev}" "${PROVISIONING_USB_MOUNT}"; then
             return 0
         fi
 
-        if [ ! -r "${article_number_file}" ]; then
+        if [ ! -r "${article_number_file}" ] && [ ! -r "${country_code_lock_file}" ]; then
             umount "${dev}"
-            echo "No article number file found on '${dev}', skipping."
+            echo "No article number file or country code lock file found on '${dev}', skipping."
             return 0
         fi
 
-        article_number="$(cat "${article_number_file}")"
-        echo "Trying to write article nr: '${article_number}'."
-        # shellcheck disable=SC2086
-        if ! i2ctransfer -y 3 w6@0x57 0x01 0x00 ${article_number}; then
-            umount "${dev}"
-            echo "Failed to write article number to EEPROM, skipping."
-            return 0
+        if [ -r "${article_number_file}" ]; then
+            article_number="$(cat "${article_number_file}")"
+            echo "Trying to write article nr: '${article_number}'."
+            # shellcheck disable=SC2086
+            if ! i2ctransfer -y 3 w6@0x57 0x01 0x00 ${article_number}; then
+                umount "${dev}"
+                echo "Failed to write article number to EEPROM, skipping."
+                return 0
+            fi
+        fi
+
+        if [ -r "${country_code_lock_file}" ]; then
+            country_code="$(cat "${country_code_lock_file}")"
+            echo "Trying to write country code lock: '${country_code}'."
+            # shellcheck disable=SC2086
+            if ! i2ctransfer -y 3 w4@0x57 0x01 0x18 ${country_code}; then
+                umount "${dev}"
+                echo "Failed to write country code lock to EEPROM, skipping."
+                return 0
+            fi
         fi
 
         umount "${dev}"
@@ -456,7 +474,7 @@ fi
 
 set_display_splash
 find_and_run_update
-check_and_set_article_number
+check_and_set_eeprom_data
 set_display_splash
 
 echo


### PR DESCRIPTION
_This PR is part of Ultimaker/opinicus#2003, and implements changes to the kernel boot script._

The current [printer provisioning process](https://ultimaker.atlassian.net/l/cp/oRBu1zNW) is documented quite extensively on our wiki. It basically boils down the following:

Early on in the boot process, the kernel init script (`initramfs/init.sh` in the repo) performs a bunch of tasks. One of these checks if a USB drive has been inserted. If that USB drive contains a single ext4 partition, it can be mounted. If the script then finds an `article_number` file in the drive  root, it programs the BOM number value in the mainboard EEPROM with the contents of the file.

We extend this by allowing an additional file to be present in the USB drive's root, `country_code_lock`. The contents of this file will be written to addres `0x0118` in the mainboard EEPROM, from where it will be picked up by the opinicus firmware in Ultimaker/opinicus#2003.

To provision a printer so that it's locked to Australia, you'd take a USB stick with a file `country_code_lock` that contains a single line of text:
```
0x41 0x55
```
To wipe the Australia lock from a printer, you'd put a file `country_code_lock` with a single line:
```
0xFF 0xFF
```
To provision a printer in a way that simply leaves the country lock as-is, just don't put this file on the USB drive.

(Do keep in mind that not all country codes are valid at this point; [see here](https://github.com/Ultimaker/opinicus/blob/d47f1813c67e589ef1cc4717cc4bfe56940e5f84/griffin/system/eeprom.py#L40-L50))