### PR TITLE
[CES-2175] Use debian stretch docker image from Cloudsmith

### DIFF
--- a/docker_env/Dockerfile
+++ b/docker_env/Dockerfile
@@ -1,30 +1,6 @@
-FROM registry.hub.docker.com/library/debian:stretch-slim
+FROM docker.cloudsmith.io/ultimaker/docker-public/deb-stretch_xcomp_gnueabihf:latest
 
 LABEL Maintainer="software-embedded-platform@ultimaker.com" \
       Comment="Ultimaker kernel build environment"
-
-RUN apt-get update && \
-    apt-get install -y \
-        bc \
-        bzip2 \
-        curl \
-        device-tree-compiler \
-        gcc \
-        gcc-arm-linux-gnueabihf \
-        gettext \
-        fakeroot \
-        kmod \
-        libssl-dev \
-        lzop \
-        make \
-        ncurses-dev \
-        openssh-client \
-        perl \
-        u-boot-tools \
-        wget \
-        xz-utils \
-    && \
-    apt-get clean && \
-    rm -rf /var/cache/apt/*
 
 COPY buildenv_check.sh buildenv_check.sh


### PR DESCRIPTION
The debian organization archived all the packages for the release we are using (Debian 9: stretch) which changes the repositories for the apt tool.

Unfortunately the docker image in docker hub (stretch-slim:latest) is not updated, so we need a manual step in the Docker file to fix those repositories path.

After renaming the repositories, I stored the resulting image in cloudsmith, so we no longer rely on third-party images to build the kernel. This image already have all the packages needed, so we also skip the packages installation phase during docker build.