### PR TITLE
[SEM-283] Remove gpio-key claim for Topcap Presence pin

### DIFF
--- a/dts/msc-sm2-imx6x.dtsi
+++ b/dts/msc-sm2-imx6x.dtsi
@@ -630,18 +630,6 @@
 		};
 	};
 
-	gpio-keys {
-		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		sw_air_manager_detected {
-			label = "air_manager_detected";
-			gpios = <&pca9555 15 0>;        /* AIR_MANAGER_DETECTED */
-			linux,code = <108>;             /* down */
-			gpio-key;
-		};
-	};
-
 	lvds0_bl: lvds0_backlight {
 		compatible = "pwm-backlight";
 		pwms = <&pwm1 0 1000000>;	/* 1000 Hz */


### PR DESCRIPTION
S-Line kernel is currently claiming the TopCap Presence pin as a GPIO-KEY pin, which blocks the userspace applications to use it as a regular GPIO pin (by means of the sysfs, for example). 
Since we don't use this pin in our firmware and in order to allow the Faber tooling to use it, we are changing the device tree to configure this pin only as a regular gpio, not a gpio-key.