### PR TITLE
UTT-553 add dorfr template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,27 @@
+Read the [Definition of Ready for Review](https://ultimaker.atlassian.net/l/cp/U0ErL5NA) for more details on the rationale behind this PR template
+
+## Description
+_A concise explanation of the changes made in this Pull Request. Consider adding_ \
+_- Why this change was necessary_ \
+_- Notable decisions made_ \
+_- Out of scope items_ \
+_- Screenshots/GIFs for visual changes_
+
+## How has this been tested
+_A brief description of what was tested, how, and on what machines. \
+If tests remain to be done, also mention that here!_
+
+
+## Ready for Review Checklist
+To help with deciding if this PR is RFR, use this checklist.
+
+The author confirms that:
+- [ ] the author has **self-reviewed** this work and is highly confident about the quality
+- [ ] this work satisfies all **acceptance criteria** that are stated in the linked ticket
+- [ ] this work has been **tested** on all product families and the process and results are documented in the above section
+- [ ] The **description** above is concise yet complete
+- [ ] the reviewer has been offered a **walkthrough** (if needed)
+- [ ] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
+- [ ] remaining `#TODO` **comments** mention a Jira ticket number
+- [ ] all **CI** checks are passing
+- [ ] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability


### PR DESCRIPTION
Read the [Definition of Ready for Review](https://ultimaker.atlassian.net/l/cp/U0ErL5NA) for more details on the rationale behind this PR template

## Description
This PR implements a template which should automatically fill the `Description` field when someone creates a PR to merge to `master`. It comes from a suggestion that surfaced during the last retrospective. It should be reviewed by a broad group within the CESTYX team so if we agree with this template, it should land in all repo's!

## How has this been tested
not, it is based on [this tutorial](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) and [this tutorial](https://axolo.co/blog/p/part-3-github-pull-request-template)


## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist. 

The author confirms that:
- [x] the author has **self-reviewed** this work and is highly confident about the quality
- [x] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [x] this work has been **tested** on all product families and the process and results are documented in the above section
- [x] The **description** above is concise yet complete
- [x] the reviewer has been offered a **walkthrough** (if needed)
- [x] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [x] remaining `#TODO` **comments** mention a Jira ticket number
- [ ] all **CI** checks are passing
- [x] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
