### PR TITLE
[CES-2487] Add the kernel command line argument "restore" to force restore mode

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -13,6 +13,7 @@ UPDATE_IMG_MOUNT="/mnt/update_img"
 UPDATE_SRC_MOUNT="/mnt/update"
 ARTICLENR_USB_MOUNT="/mnt/usb"
 RESCUE_SHELL="no"
+FORCE_RESTORE_MODE="no"
 
 PREFIX="${PREFIX:-/usr/}"
 EXEC_PREFIX="${PREFIX}"
@@ -89,8 +90,8 @@ restart()
 restore_complete_loop()
 {
     while true; do
-    	echo "Restore complete, remove the recovery SD card and powercycle the printer."
-    	sleep 30s
+        echo "Restore complete, remove the recovery SD card and powercycle the printer."
+        sleep 30s
     done 
 }
 
@@ -220,7 +221,7 @@ check_and_set_article_number()
 find_and_run_update()
 {
     SOFTWARE_INSTALL_MODE="update"
-    if isBootingRestoreImage; then
+    if isBootingRestoreImage || [ "${FORCE_RESTORE_MODE}" = "yes" ]; then
         SOFTWARE_INSTALL_MODE="restore"
     fi
 
@@ -299,9 +300,9 @@ find_and_run_update()
             break
         fi
 
-    	# After restore do not remove the file and loop endlessly
-    	if [ "${SOFTWARE_INSTALL_MODE}" = "restore" ]; then
-    	   restore_complete_loop
+        # After restore do not remove the file and loop endlessly
+        if [ "${SOFTWARE_INSTALL_MODE}" = "restore" ]; then
+           restore_complete_loop
         fi
 
         if ! rm "${update_tmpfs_mount}/${UPDATE_IMAGE:?}"; then
@@ -329,6 +330,9 @@ parse_cmdline()
         ;;
         rescue)
             RESCUE_SHELL="yes"
+        ;;
+        restore)
+            FORCE_RESTORE_MODE="yes"
         ;;
         ro)
             rwmode="ro"


### PR DESCRIPTION
## Description
This is useful if one wants to wipe out the printer during a update procedure without using the recovery method (with SD card).
Providing the argument `restore` in the kernel command line will trigger a restore/recovery update, not a regular update where we keep files from previous firmware.

## How has this been tested
The `restore` argument was several times provided in the kernel command line argument and the update system triggered the restore mode gracefully. 

## How to use it
The kernel command line is issued by UBoot, so we need to change one of its environment variable in order to pass the argument to the kernel. 
You will need a serial cable connected to the mainboard, in the Console port.
- During the UBoot boot, press any key in the countdown to stop the automatic boot
- Enter this command to edit the `mmcargs` variable: `env edit mmcargs`
- Add the `restore` keyword to the end of the line and press <enter>
- type `boot` and <enter> to proceed with the boot.

![image](https://github.com/Ultimaker/um-kernel/assets/5216531/42fbb349-91d1-42a4-8951-1daa4999f8f0)


## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
