### PR TITLE
[CES-2563] Enable Second White LEDs strip for Calin Lights

### DIFF
--- a/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
+++ b/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
@@ -129,22 +129,22 @@
         nxp,totem-pole;
         nxp,inverted-out;
         nxp,hw-blink;
-        red@0 {
-            label = "red:cabin_light";
+        white4 {
+            label = "white4:cabin_light";
             reg = <0>;
-            linux,default-trigger = "none";
+            linux,default-trigger = "default-on";
         };
-        green@1 {
-            label = "green:cabin_light";
+        white3 {
+            label = "white3:cabin_light";
             reg = <1>;
-            linux,default-trigger = "none";
+            linux,default-trigger = "default-on";
         };
-        blue@2 {
-            label = "blue:cabin_light";
+        white2 {
+            label = "white2:cabin_light";
             reg = <2>;
-            linux,default-trigger = "none";
+            linux,default-trigger = "default-on";
         };
-        white@3 {
+        white {
             label = "white:cabin_light";
             reg = <3>;
             linux,default-trigger = "default-on";


### PR DESCRIPTION
## Description
Factor 4 is not expected to have RGB cabin lights, only white LED strips. We currently use 2 channels for 2 strips, so renaming the Mainboard Cabin LEDs channels from Red, Blue, Green, White to White4, White3, White2 and White.

## How has this been tested
The kernel was tested in Colorado and both LEDs strips was working properly. All the changed channels were exposed to the sysfs.

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
