### PR TITLE
[CES-2649]  Add Support also to PCA9633 Cabin Led driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "linux"]
 	path = linux
-	url = https://github.com/Ultimaker/linux
+	url = git@github.com:Ultimaker/linux.git

--- a/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
+++ b/dts/imx8mm-cgtsx8m-ultimain5.0-lvds-1024x600.dts
@@ -150,6 +150,36 @@
             linux,default-trigger = "default-on";
         };
     };
+
+    cabin_light_2: pca9633@62 {
+        compatible = "nxp,pca9633";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reg = <0x62>;
+        nxp,totem-pole;
+        nxp,inverted-out;
+        nxp,hw-blink;
+        white4 {
+            label = "white4:cabin_light";
+            reg = <0>;
+            linux,default-trigger = "default-on";
+        };
+        white3 {
+            label = "white3:cabin_light";
+            reg = <1>;
+            linux,default-trigger = "default-on";
+        };
+        white2 {
+            label = "white2:cabin_light";
+            reg = <2>;
+            linux,default-trigger = "default-on";
+        };
+        white {
+            label = "white:cabin_light";
+            reg = <3>;
+            linux,default-trigger = "default-on";
+        };
+    };
 };
 
 /* Set pin names for IMXRT control lines */


### PR DESCRIPTION
## Description
This PR adds 2 changes in um-kernel, one in the device tree and another in the linux kernel:

- The device tree now includes one more PCA9633 description for the Factor 4 mainboard cabin lights - the mainboard can then be mounted with a PCA9632 (I2C addr 0x61) or PCA9633 driver (I2C addr 0x62). Both descriptions points to the same sysfs endpoints, so the used device is transparent to the application layer.

- The linux kernel PCA963x driver does not check if the device is present in the bus before registering it. That causes fake device enumeration in /sys/class/leds - they are there but does not work because the device is not present in the bus. The fix adds a dummy ready before enumeration to check if the device is present before setting it up.

### Important:
To see the change in the Linux Kernel, please check the link below:
https://github.com/Ultimaker/linux/commit/cac8c93cbc460b814420e1f20163801b23d70f3f?diff=split&w=1

## How has this been tested
The kernel was tested in 2 different mainboards, with the PCA9632 and PCA9633 and in both it works as expected.

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
