### PR TITLE
Sem 146 no wifi worries mate imx8

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -182,6 +182,32 @@ isBootingRestoreImage()
 
 check_and_set_eeprom_data()
 {
+    # The printer's mainboard EEPROM can be "provisioned" by inserting a USB drive during boot.
+    # The USB drive must contain a single ext4 partition, containing one or more of the following
+    # files:
+    #
+    # - article_number
+    #   A single-line text file, containing the printer's BOM number in hex notation, exactly 4 bytes.
+    #   For instance, for an S5R2 printer, the file should contain the following line:
+    #       0x00 0x03 0x45 0xCB
+    #   (this is equivalent to decimal 214475).
+    #
+    # - country_code_lock
+    #   A single line text file, containing the printer's locked country code, in hex notation,
+    #   exactly 2 bytes.
+    #   For instance, to lock the printer to the AU country code, the file should contain the line:
+    #     0x41 0x55
+    #   To clear the lock, the file should contain:
+    #     0xFF 0xFF
+    #
+    # If either of these files is missing, no data is written to that part of the EEPROM.
+    #
+    # Relevant EEPROM layout here:
+    # (See opinicus for full details on EEPROM layout)
+    #   0x0100 - 0x0104     BOM number / article number
+    #   ...
+    #   0x0118 - 0x0120     Locked country code
+
     dev="/dev/sda1"
     article_number_file="${PROVISIONING_USB_MOUNT}/article_number"
     country_code_lock_file="${PROVISIONING_USB_MOUNT}/country_code_lock"

--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -207,17 +207,19 @@ check_and_set_eeprom_data()
     #   0x0100 - 0x0104     BOM number / article number
     #   ...
     #   0x0118 - 0x0120     Locked country code
+    #
+    # The primary location to record and use the addresses is the opinucus/libEeprom/mainBoard.py file.
 
     dev="/dev/sda1"
     article_number_file="${PROVISIONING_USB_MOUNT}/article_number"
     country_code_lock_file="${PROVISIONING_USB_MOUNT}/country_code_lock"
 
     # Get the article number from EEPROM
-    art_num=$(i2ctransfer -y 3 w2@0x57 0x01 0x00 r4)
+    art_num=$(i2ctransfer -y 1 w2@0x57 0x01 0x00 r4)
     echo "---> Article number read from EEPROM: >${art_num}<"
 
     # Get the country code lock from EEPROM
-    country_code_lock=$(i2ctransfer -y 3 w2@0x57 0x01 0x18 r2)
+    country_code_lock=$(i2ctransfer -y 1 w2@0x57 0x01 0x18 r2)
     echo "--> Country code lock read from EEPROM: >${country_code_lock}<"
 
     # Wait for the USB drive to become visible; max 5 seconds.
@@ -228,7 +230,7 @@ check_and_set_eeprom_data()
     done
 
     echo "Attempting to mount '${dev}'."
-    if ! mount -t f2fs,ext4,vfat,auto -o exec,noatime "${dev}" "${PROVISIONING_USB_MOUNT}"; then
+    if ! mount -t f2fs,ext4,vfat,auto -o ro,exec,noatime "${dev}" "${PROVISIONING_USB_MOUNT}"; then
         return 0
     fi
 
@@ -236,7 +238,7 @@ check_and_set_eeprom_data()
         article_number="$(cat "${article_number_file}")"
         echo "Trying to write article nr: '${article_number}'."
         # shellcheck disable=SC2086
-        if ! i2ctransfer -y 3 w6@0x57 0x01 0x00 ${article_number}; then
+        if ! i2ctransfer -y 1 w6@0x57 0x01 0x00 ${article_number}; then
             echo "Failed to write article number to EEPROM, skipping."
         fi
     else
@@ -247,7 +249,7 @@ check_and_set_eeprom_data()
         country_code="$(cat "${country_code_lock_file}")"
         echo "Trying to write country code lock: '${country_code}'."
         # shellcheck disable=SC2086
-        if ! i2ctransfer -y 3 w4@0x57 0x01 0x18 ${country_code}; then
+        if ! i2ctransfer -y 1 w4@0x57 0x01 0x18 ${country_code}; then
             echo "Failed to write country code lock to EEPROM, skipping."
         fi
     else


### PR DESCRIPTION
## Description
This is essentially a copy of #176 but form imx8
The edits during cherry-picking were rather small to be able to do this.
This is somewhat related to https://github.com/Ultimaker/opinicus/pull/2300 which also writes the eeprom but can deal with the crc checksum we use for imx 8 machines. Since we don't want to impact the workflow in the factory and so they can do both the locking and the article number/bom assignment at the same time saving a reboot.

The description stolen from that PR follows below:

_This PR is part of Ultimaker/opinicus#2003, and implements changes to the kernel boot script._

The current [printer provisioning process](https://ultimaker.atlassian.net/l/cp/oRBu1zNW) is documented quite extensively on our wiki. It basically boils down the following:

Early on in the boot process, the kernel init script (`initramfs/init.sh` in the repo) performs a bunch of tasks. One of these checks if a USB drive has been inserted. If that USB drive contains a single ext4 partition, it can be mounted. If the script then finds an `article_number` file in the drive  root, it programs the BOM number value in the mainboard EEPROM with the contents of the file.

We extend this by allowing an additional file to be present in the USB drive's root, `country_code_lock`. The contents of this file will be written to addres `0x0118` in the mainboard EEPROM, from where it will be picked up by the opinicus firmware in Ultimaker/opinicus#2003.

To provision a printer so that it's locked to Australia, you'd take a USB stick with a file `country_code_lock` that contains a single line of text:
```
0x41 0x55
```
To wipe the Australia lock from a printer, you'd put a file `country_code_lock` with a single line:
```
0xFF 0xFF
```
To provision a printer in a way that simply leaves the country lock as-is, just don't put this file on the USB drive.

(Do keep in mind that not all country codes are valid at this point; [see here](https://github.com/Ultimaker/opinicus/blob/d47f1813c67e589ef1cc4717cc4bfe56940e5f84/griffin/system/eeprom.py#L40-L50))
## How has this been tested
By placing the text files mentioned above on a ext4 formatted usb stick and rebooting.


## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [x] the author has **self-reviewed** this work and is highly confident about the quality
- [x] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [ ] this work has been **tested** on all product families and the process and results are documented in the above section
- [x] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [ ] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [x] remaining `#TODO` **comments** mention a Jira ticket number
- [x] all **CI** checks are passing
- [x] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
