### PR TITLE
[SEM-503] UMBus Comm Issue

### DIFF
--- a/dts/ultimainboard5-lvds.dtsi
+++ b/dts/ultimainboard5-lvds.dtsi
@@ -11,19 +11,19 @@
    That prevents multiple enumeration of /dev/videoX devices for
    the camera */
 &vpu_g1 {
-	status = "disabled";
+    status = "disabled";
 };
 
 &vpu_g2 {
-	status = "disabled";
+    status = "disabled";
 };
 
 &vpu_h1 {
-	status = "disabled";
+    status = "disabled";
 };
 
 &vpu_v4l2 {
-	status = "disabled";
+    status = "disabled";
 };
 
 
@@ -52,12 +52,33 @@
     >;
 };
 
+/* SEM-503: We need to connect the IMX8MM pad UART3_RXD and UART3_TXD to the GPIO5 controller,
+   removing them from the UART1 controller. So we need to re-define these pin control groups 
+   here, since it is not possible to delete a pin from a fsl,pin array */
+   
 &pinctrl_gpio5 {
     fsl,pins = <
         MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4         0x140 /* GPIO5 / PWMOUT */
+        MX8MM_IOMUXC_UART3_RXD_GPIO5_IO26       0x140 /* SER2_RTS# - Used for UMBus Drive Enable */
+        MX8MM_IOMUXC_UART3_TXD_GPIO5_IO27       0x140 /* SER2_CTS */
     >;
 };
 
+&pinctrl_uart1 {
+    fsl,pins = <
+        MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX	    0x140 /* Added by ticket SEM-503 */
+        MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX	    0x140 /* Added by ticket SEM-503 */
+    >;
+};
+
+&pinctrl_uart1_sleep {
+    fsl,pins = <
+        MX8MM_IOMUXC_UART1_RXD_GPIO5_IO22	    0x100 /* Added by ticket SEM-503 */
+        MX8MM_IOMUXC_UART1_TXD_GPIO5_IO23	    0x100 /* Added by ticket SEM-503 */
+    >;
+};
+
+    
 /* Add GPIOs pinctrl for Ultboard 5. */
 
 /* GPIO PAD setting */
@@ -177,6 +198,24 @@
                       "", "", "", "", "IMXRT_BootMode_En", "SAFETY_ENABLED", "", "";
 };
 
+&gpio5 {
+
+/* SEM-503: The IMX8MM UART3_RXD pad (SMARC P138) is connected to the UMBus Drive Enable pin. It should be connected to VCC5 in HW,
+   but up to now (2025-01-22) the current ultimainboard 5 still has it connected to wired to the SoM, without any specific
+   reason / purpose. So here we claim this pin as gpio-hog and set it to high level and then it cannot be changed in runtime */
+   
+    umbus_drive_enable_hog {
+        gpio-hog;
+        gpios = <26 GPIO_ACTIVE_HIGH>;
+        output-high;
+        line-name = "umbus_drive_en_hog";
+    };
+};
+
+&uart1 {
+/* SEM-503: Remove the rtscts property for the UART1 */
+    /delete-property/ fsl,uart-has-rtscts;
+};
 
 /* Ultimainboard J8 debug console. We cannot use DMA, it uses proprietary firmware drivers.  */
 &uart4 { /* SER1 */

--- a/dts/ultimainboard5-lvds.dtsi
+++ b/dts/ultimainboard5-lvds.dtsi
@@ -32,17 +32,19 @@
     fsl,pins = <
         MX8MM_IOMUXC_GPIO1_IO07_GPIO1_IO7       0x140 /* GPIO0 / CSI0 PWR */
         MX8MM_IOMUXC_GPIO1_IO15_GPIO1_IO15      0x140 /* TEST# */
+        MX8MM_IOMUXC_SAI1_RXD0_GPIO4_IO2		0x140 /* GPIO12 */
+		MX8MM_IOMUXC_SAI1_RXD1_GPIO4_IO3		0x140 /* GPIO13 */        
     >;
 };
 
 &pinctrl_gpio4 {
     fsl,pins = <
         MX8MM_IOMUXC_SAI3_RXC_GPIO4_IO29        0x080 /* GPIO4 / SAFETY_ENABLED (input) */
-        MX8MM_IOMUXC_SAI1_RXC_GPIO4_IO1         0x100 /* GPIO7 / RESET_HUB*/
-        MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28       0x080 /* GPIO6 / IMXRT BootMode Enable*/       
+        MX8MM_IOMUXC_SAI3_RXFS_GPIO4_IO28       0x080 /* GPIO6 / SOM_BOOT (IMXRT BootMode Enable) */
+        MX8MM_IOMUXC_SAI1_RXC_GPIO4_IO1         0x100 /* GPIO7 / USB RESET_HUB# */
         MX8MM_IOMUXC_SAI1_TXC_GPIO4_IO11        0x140 /* GPIO9 */
-        MX8MM_IOMUXC_SAI1_TXFS_GPIO4_IO10       0x100 /* GPIO10 / U12 WRITE PROTECT */
-        MX8MM_IOMUXC_SAI1_MCLK_GPIO4_IO20       0x080 /* GPIO11 */
+        MX8MM_IOMUXC_SAI1_TXFS_GPIO4_IO10       0x100 /* GPIO10 / U12 EEPROM WRITE PROTECT */
+        MX8MM_IOMUXC_SAI1_MCLK_GPIO4_IO20       0x080 /* GPIO11 / SOM_nRST (IMXRT_nReset) */
         MX8MM_IOMUXC_SAI1_TXD3_GPIO4_IO15       0x140 /* PM_CHARGING# */
         MX8MM_IOMUXC_SAI1_TXD2_GPIO4_IO14       0x140 /* PM_CHARGER_PRSNT# */
         MX8MM_IOMUXC_SAI1_TXD4_GPIO4_IO16       0x140 /* BOOT_SEL0# */
@@ -91,9 +93,9 @@
 &iomuxc {
     pinctrl_leds_1: ledsgrp-1 {
         fsl,pins = <
-            MX8MM_IOMUXC_SPDIF_TX_GPIO5_IO3         0x100 /* GPIO1 / CSI1 PWR */
-            MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5    0x100 /* GPIO3 / CSI1 RST */
-            MX8MM_IOMUXC_GPIO1_IO06_GPIO1_IO6       0x100 /* GPIO2 / CSI0 RST */
+            MX8MM_IOMUXC_SPDIF_TX_GPIO5_IO3         0x100 /* GPIO1 / CSI1 PWR / Led-1 Error */
+            MX8MM_IOMUXC_GPIO1_IO06_GPIO1_IO6       0x100 /* GPIO2 / CSI0 RST / SD-LED */
+            MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5    0x100 /* GPIO3 / CSI1 RST / Led-0 Kernel Heartbeat */
         >;
     };
     


### PR DESCRIPTION
## Description
For some unknown / forgotten reason, the UMBus Drive Enable pin is connected to the serial (uart1) RTS pin, which makes no sense at all.
During update from kernel 4.14 to 5.15, the new UART driver began to drive this pin even when the serial is not open with hw flow control, blocking the UMbus communication.
The solution is a change in the device tree to remove the control of the pad USART3_RXD (wired to the UMBus Drive Enable signal) from the UART1 peripheral and connects it to the GPIO5 peripheral. That pad is now a gpio-hog pin of GPIO5 set to HIGH level.

## How has this been tested
It was tested in an S6 and S8. The UMBus communication worked fine, including for firmware update.

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
