### PR TITLE
[CES-3073] Integrate SEM-442 in RevB

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -25,13 +25,9 @@ BOOT_PARTITION="${EMMC_DEV}p1"
 SYSTEM_UPDATE_ENTRYPOINT="start_update.sh"
 UPDATE_DEVICES="/dev/mmcblk[0-9]p[0-9]"
 
-#uc2 : UltiController 2 (UM3,UM3E) This UltiController is not considered here anymore
-#uc3 : UltiController 3 (S5,S5r2,S3)
-#uc4 : UltiController 4 (Colorado)
-DISPLAY_TYPE="uc4"
 UM_SPLASH="umsplash.fb"
 FB_DEVICE="/dev/fb0"
-
+BOM_NUMBER="227380"
 
 BB_BIN="/bin/busybox"
 CMDS=" \
@@ -230,6 +226,15 @@ check_and_set_eeprom_data()
     art_num=$(i2ctransfer -y 1 w2@0x57 0x01 0x00 r4)
     echo "---> Article number read from EEPROM: >${art_num}<"
 
+    art_num_hex=""
+    for hex in $art_num; do
+        art_num_hex="${art_num_hex}${hex#0x}"  # Remove the "0x" prefix
+    done
+    BOM_NUMBER=$(printf "%d\n" "0x$art_num_hex")
+
+    echo "---> Article number in decimal: >${BOM_NUMBER}<"
+
+
     # Get the country code lock from EEPROM
     country_code_lock=$(i2ctransfer -y 1 w2@0x57 0x01 0x18 r2)
     echo "--> Country code lock read from EEPROM: >${country_code_lock}<"
@@ -346,9 +351,9 @@ find_and_run_update()
             echo "Warning: unable to unmount '${UPDATE_IMG_MOUNT}'."
         fi
 
-        echo "Got '${SYSTEM_UPDATE_ENTRYPOINT}' script, trying to execute."
-        if ! "${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT}" "${update_tmpfs_mount}/${UPDATE_IMAGE}" "${EMMC_DEV}" "${DISPLAY_TYPE}" "${SOFTWARE_INSTALL_MODE}"; then
-            echo "Error, update failed: executing '${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT} ${update_tmpfs_mount}/${UPDATE_IMAGE} ${EMMC_DEV} ${DISPLAY_TYPE} ${SOFTWARE_INSTALL_MODE}'."
+        echo "Got '${SYSTEM_UPDATE_ENTRYPOINT}' script, trying to execute, with ${BOM_NUMBER}."
+        if ! "${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT}" "${update_tmpfs_mount}/${UPDATE_IMAGE}" "${EMMC_DEV}" "${BOM_NUMBER}" "${SOFTWARE_INSTALL_MODE}"; then
+            echo "Error, update failed: executing '${update_tmpfs_mount}/${SYSTEM_UPDATE_ENTRYPOINT} ${update_tmpfs_mount}/${UPDATE_IMAGE} ${EMMC_DEV} ${BOM_NUMBER} ${SOFTWARE_INSTALL_MODE}'."
             critical_error
             break
         fi
@@ -459,8 +464,8 @@ if [ "${RESCUE_SHELL}" = "yes" ]; then
     rescue_shell
 fi
 set_display_splash
-find_and_run_update
 check_and_set_eeprom_data
+find_and_run_update
 
 echo
 echo "INITRAMFS: Handing over to the main system:"


### PR DESCRIPTION
## Description
The PR from SEM-442 was missing from the `master/imx8_revB`. This PR fix this mistake.

## How has this been tested
A build was made with this new kernel and now we can see the progress images during the install process. 

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
