### PR TITLE
[CES-3125] Trigger restore for um restore filename

### DIFF
--- a/initramfs/init.sh
+++ b/initramfs/init.sh
@@ -9,6 +9,7 @@ set -eu
 
 ROOT_MOUNT="/mnt/root"
 UPDATE_IMAGE="um-update.swu"
+RESTORE_TRIGGER_IMAGE="um-restore.swu"
 UPDATE_IMG_MOUNT="/mnt/update_img"
 UPDATE_SRC_MOUNT="/mnt/update"
 PROVISIONING_USB_MOUNT="/mnt/usb"
@@ -300,11 +301,17 @@ find_and_run_update()
             continue
         fi
 
-        if [ ! -r "${UPDATE_SRC_MOUNT}/${UPDATE_IMAGE}" ]; then
+        if [ ! -r "${UPDATE_SRC_MOUNT}/${UPDATE_IMAGE}" ] && [ ! -r "${UPDATE_SRC_MOUNT}/${RESTORE_TRIGGER_IMAGE}" ]; then
             umount "${dev}"
-            echo "No update image '${UPDATE_IMAGE}' found on '${dev}', trying next."
+            echo "No update image '${UPDATE_IMAGE}' or '${RESTORE_TRIGGER_IMAGE}' found on '${dev}', trying next."
             continue
         fi
+
+        # If there is a file to trigger the restore mode, rename it to update and set the restore flag
+        if [ -r "${UPDATE_SRC_MOUNT}/${RESTORE_TRIGGER_IMAGE}" ]; then
+            SOFTWARE_INSTALL_MODE="restore"
+            mv "${UPDATE_SRC_MOUNT}/${RESTORE_TRIGGER_IMAGE}" "${UPDATE_SRC_MOUNT}/${UPDATE_IMAGE}"
+        fi;
 
         update_tmpfs_mount="$(mktemp -d)"
         echo "Found '${UPDATE_IMAGE}' on '${dev}', moving to tmpfs."


### PR DESCRIPTION
## Description
When adding an update file renamed to `um-restore.swu` to the printer root filesystem, the system update will trigger a restore flash, not an update - similar to flashing with a SD Card.

## How has this been tested
Both methods were tested (um-update and um-restore) and both worked as expected.

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [X] the author has **self-reviewed** this work and is highly confident about the quality
- [X] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [X] this work has been **tested** on all product families and the process and results are documented in the above section
- [X] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [X] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [X] remaining `#TODO` **comments** mention a Jira ticket number
- [X] all **CI** checks are passing
- [X] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
