### PR TITLE
[CES-3323] Set NGP Proto screens to the correct touch orientation

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,6 +10,7 @@ ARTNUM_FILE="/etc/ultimaker_firmware"
 TARGET_DTS="cgtsx8m-ultimain5.dtb"
 UC32_DTS="ulticontroller3.2-lvds-800x320.dtb"
 UC4_DTS="ulticontroller4.0-lvds-1024x600.dtb"
+UC4_INV_DTS="ulticontroller4.1-lvds-1024x600.dtb"
 
 if [ "$1" = "configure" ]; then
     # During the bootstrap configuration stage, if the kernel is configured
@@ -28,6 +29,10 @@ if [ "$1" = "configure" ]; then
         227380 | 105*)
             echo "-> Setting Ulticontroller 4.0 LVDS device tree."
             ln -sf "${UC4_DTS}" "/boot/${TARGET_DTS}"
+            ;;
+        109*)
+            echo "-> Setting Ulticontroller 4.0 LVDS Inverted device tree."
+            ln -sf "${UC4_INV_DTS}" "/boot/${TARGET_DTS}"
             ;;
     # Fallback to the larger screen
         *)

--- a/dts/Readme.md
+++ b/dts/Readme.md
@@ -1,8 +1,9 @@
 ### Device Tree Selection
 
-We have 2 device trees, one for each display currently supported by **Ultimainboard 5**:
+We have 3 device trees, one for each display currently supported by **Ultimainboard 5**:
 
-- *Ulticontroller 4* at 1024x600 (Factor 4, Falcon): `ulticontroller4.0-lvds-1024x600.dts`
+- *Ulticontroller 4.1-lvds-1024x600.dts (NGP Protos): `ulticontroller4.1-lvds-1024x600.dts`
+- *Ulticontroller 4.0 at 1024x600 (Factor 4, Falcon): `ulticontroller4.0-lvds-1024x600.dts`
 - *Ultricontroller 3.2 LVDS* at 800x600 (S6 and S8): `ulticontroller3.2-lvds-800x320.dts`
 
 Both device trees sources includes the Ultimainboard 5 device tree: `ultimainboard5-lvds.dtsi`.

--- a/dts/ulticontroller4.1-lvds-1024x600.dts
+++ b/dts/ulticontroller4.1-lvds-1024x600.dts
@@ -3,68 +3,11 @@
  * Copyright (C) 2020 - Raymond Siudak <raysiudak@gmail.com>
 */
 
-#include "ultimainboard5-lvds.dtsi"
-
-/ {
-    panel-lvds {
-        width-mm = <155>;
-        height-mm = <86>;
-
-        data-mapping = "vesa-24";
-
-        panel-timing {
-            clock-frequency = <51206400>;
-            hactive = <1024>;
-            vactive = <600>;
-            hsync-len = <2>;
-            hfront-porch = <120>;
-            hback-porch = <120>;
-            vsync-len = <20>;
-            vfront-porch = <30>;
-            vback-porch = <180>;
-        };
-    };
-};
+#include "ulticontroller4.0-lvds-1024x600.dts"
 
 &i2c2 {
-    clock-frequency = <100000>;
     panel_touchscreen: ft5426@38 {
-        compatible = "edt,edt-ft5406";
-        reg = <0x38>;
-        poll-interval = <30>;
-        reset-gpios = <&panel_gpio 3 GPIO_ACTIVE_LOW>;
-        touchscreen-size-x = <1024>;
-        touchscreen-size-y = <600>;
-    };
-
-    panel_gpio: pca9536@41 {
-        compatible = "nxp,pca9536";
-        gpio-controller;
-        #gpio-cells = <2>;
-        reg = <0x41>;
-        gpio-line-names = "BUZZER_EN", "DOOR", "DISP_RST", "TOUCH_RST";
-    };
-
-    panel_lights: pca9632@60 {
-        compatible = "nxp,pca9632";
-        #address-cells = <1>;
-        #size-cells = <0>;
-        reg = <0x60>;
-        nxp,totem-pole;
-        nxp,hw-blink;
-        panel_backlight: backlight@3 {
-            label = "white:panel_backlight";
-            reg = <3>;
-            linux,default-trigger = "default-on";
-        };
-    };
-
-    edid_eeprom: 24c32@50 { /* 24LC02B 2K Microchip EEPROM */
-        // compatible = "24c32", "atmel,24c32";
-        compatible = "24c32";
-        reg = <0x50>;
-        pagesize = <32>;
-        size = <4096>;  // 32Kb (4KB) EEPROM size
+        /delete-property/ touchscreen-inverted-x;
+        /delete-property/ touchscreen-inverted-y;
     };
 };
-

--- a/dts/ulticontroller4.1-lvds-1024x600.dts
+++ b/dts/ulticontroller4.1-lvds-1024x600.dts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 - Ultimaker B.V.
+ * Copyright (C) 2020 - Raymond Siudak <raysiudak@gmail.com>
+*/
+
+#include "ultimainboard5-lvds.dtsi"
+
+/ {
+    panel-lvds {
+        width-mm = <155>;
+        height-mm = <86>;
+
+        data-mapping = "vesa-24";
+
+        panel-timing {
+            clock-frequency = <51206400>;
+            hactive = <1024>;
+            vactive = <600>;
+            hsync-len = <2>;
+            hfront-porch = <120>;
+            hback-porch = <120>;
+            vsync-len = <20>;
+            vfront-porch = <30>;
+            vback-porch = <180>;
+        };
+    };
+};
+
+&i2c2 {
+    clock-frequency = <100000>;
+    panel_touchscreen: ft5426@38 {
+        compatible = "edt,edt-ft5406";
+        reg = <0x38>;
+        poll-interval = <30>;
+        reset-gpios = <&panel_gpio 3 GPIO_ACTIVE_LOW>;
+        touchscreen-size-x = <1024>;
+        touchscreen-size-y = <600>;
+    };
+
+    panel_gpio: pca9536@41 {
+        compatible = "nxp,pca9536";
+        gpio-controller;
+        #gpio-cells = <2>;
+        reg = <0x41>;
+        gpio-line-names = "BUZZER_EN", "DOOR", "DISP_RST", "TOUCH_RST";
+    };
+
+    panel_lights: pca9632@60 {
+        compatible = "nxp,pca9632";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reg = <0x60>;
+        nxp,totem-pole;
+        nxp,hw-blink;
+        panel_backlight: backlight@3 {
+            label = "white:panel_backlight";
+            reg = <3>;
+            linux,default-trigger = "default-on";
+        };
+    };
+
+    edid_eeprom: 24c32@50 { /* 24LC02B 2K Microchip EEPROM */
+        // compatible = "24c32", "atmel,24c32";
+        compatible = "24c32";
+        reg = <0x50>;
+        pagesize = <32>;
+        size = <4096>;  // 32Kb (4KB) EEPROM size
+    };
+};
+


### PR DESCRIPTION
## Description
With this PR, if a printer has the BOM number 109*, then it is an NGP printer and uses a large Colorado like screen, except it is not an inverted screen like the production printers.

So we use a different dts for machines with BOM's 109* which is very similar to the ulticontroller4.0-lvds-1024x600.dts, just the inversion of the x and y is removed.

## How has this been tested
Installed this um-kernel package on NGP proto, after install teh touch response of the screen is correct.

## Ready for Review Checklist
To help with deciding if this PR is RFR, use this checklist.

The author confirms that:
- [x] the author has **self-reviewed** this work and is highly confident about the quality
- [x] this work satisfies all **acceptance criteria** that are stated in the linked ticket
- [x] this work has been **tested** on all product families and the process and results are documented in the above section
- [x] The **description** above is concise yet complete
- [ ] the reviewer has been offered a **walkthrough** (if needed)
- [x] the code is **cleaned** from any rubbish (e.g. meaningless comments, log-spamming, etc...)
- [x] remaining `#TODO` **comments** mention a Jira ticket number
- [x] all **CI** checks are passing
- [x] all **commits** are (re)structured to be meaningful and clearly arranged, and all are prepended with the ticket number for traceability
